### PR TITLE
fix: Connexion frontend-backend Windows et nom de paquet deb

### DIFF
--- a/src/frontend/src-tauri/tauri.conf.json
+++ b/src/frontend/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "THÉRÈSE",
+  "productName": "THERESE",
   "version": "0.1.15",
   "identifier": "fr.synoptia.therese",
   "build": {

--- a/src/frontend/src/components/SplashScreen.tsx
+++ b/src/frontend/src/components/SplashScreen.tsx
@@ -40,7 +40,10 @@ async function probeHealth(baseUrl: string): Promise<boolean> {
       const data = await res.json();
       // Vérifier status + version pour s'assurer que c'est bien THÉRÈSE
       // (évite de se connecter à un autre service sur le même port)
-      return data.status === 'healthy' && typeof data.version === 'string';
+      // Accepter "degraded" : le backend tourne mais un service non-critique
+      // n'est pas prêt (ex: embeddings en cours de chargement sur Windows)
+      const validStatus = data.status === 'healthy' || data.status === 'degraded';
+      return validStatus && typeof data.version === 'string';
     }
     return false;
   } catch {


### PR DESCRIPTION
## Correctif

**Bugs :** Frontend ne se connecte pas au backend sur Windows + dpkg refuse les accents dans le nom du paquet .deb

### 1. SplashScreen - statut degraded (Windows)
**Cause :** `probeHealth()` n'acceptait que le statut `healthy`. Sur Windows sans mode developpeur, sentence-transformers echoue a cause des symlinks HuggingFace, le backend reste en `degraded` et le frontend timeout apres 60s.
**Solution :** Accepter `healthy` et `degraded` comme statuts valides dans `probeHealth()`.

### 2. productName sans accent (Linux .deb)
**Cause :** `productName: "THERESE"` (avec accent) produit un nom de paquet deb non-ASCII que dpkg rejette.
**Solution :** `productName: "THERESE"` sans accent. Le titre de la fenetre garde l'accent via le champ `title`.

### Bug ELF scipy (non corrige)
Le crash ELF alignment sur Linux kernel 6.x est un probleme de build pipeline (wheels manylinux), pas de code source. Analyse detaillee dans la fiche bug. Solutions : compiler scipy depuis les sources ou utiliser conda-forge.

## Tests
- [x] pytest backend OK (pas de regression - 367 passed, echecs preexistants)
- [x] vitest frontend OK (pas de regression - 43 passed, echecs preexistants)
- [x] ruff lint OK

## Review challenger
- Verdict : APPROUVE
- Iterations : 1/3

## Fichiers modifies
- `src/frontend/src/components/SplashScreen.tsx`
- `src/frontend/src-tauri/tauri.conf.json`