### PR TITLE
fix: Ajout du champ address dans ContactResponse (CRM)

### DIFF
--- a/src/backend/app/routers/memory.py
+++ b/src/backend/app/routers/memory.py
@@ -314,6 +314,7 @@ def _contact_to_response(contact: Contact) -> ContactResponse:
         company=contact.company,
         email=contact.email,
         phone=contact.phone,
+        address=contact.address,
         notes=contact.notes,
         tags=json.loads(contact.tags) if contact.tags else None,
         # CRM fields (Phase 5)


### PR DESCRIPTION
## Correctif

**Bug :** CRM Pipeline - 'Impossible de contacter le serveur' lors de la creation d'un contact
**Signale par :** Capov (Richard) sur macOS M4 Max, v0.1.14-alpha

**Cause :** `_contact_to_response()` dans `memory.py` ne passait pas le champ `address` au schema `ContactResponse`. Pydantic levait une `ValidationError` (champ requis manquant), le backend retournait une 500, et le frontend interpretait ca comme une erreur reseau ('Impossible de contacter le serveur').

**Solution :** Ajout de `address=contact.address` dans `_contact_to_response()`.

## Tests
- [x] pytest tests/test_routers_crm_full.py::TestCRMContacts - 4 passed (etaient 4 failed avant)
- [x] pytest tests/test_routers_memory.py - 16 passed
- [x] ruff lint OK

## Review challenger
- Fix trivial (1 ligne), pas de challenger necessaire

## Fichiers modifies
- `src/backend/app/routers/memory.py`