### PR TITLE
fix: Batch v0.2.6 - Ollama 404, XLSX tronqué, contraste dropdown, bouton stop, réponses légères

### DIFF
--- a/src/backend/app/services/llm.py
+++ b/src/backend/app/services/llm.py
@@ -191,7 +191,13 @@ class LLMService:
 ## Ton rôle
 Tu aides les entrepreneurs et TPE avec leurs tâches quotidiennes.
 Tu es efficace, professionnelle et tu utilises un français naturel et fluide.
-Réponds de manière concise mais complète.
+
+## Style de réponse
+- Réponds de manière concise et directe. Va droit au but.
+- N'utilise PAS de tableaux markdown sauf si l'utilisateur le demande explicitement.
+- Privilégie les listes à puces ou le texte simple pour les récapitulatifs.
+- Pas d'emojis de statut, pas de dashboards non sollicités.
+- Si tu fais un récap en fin de réponse, utilise des listes à puces simples.
 
 ## Mémoire persistante
 Tu as accès à une mémoire persistante contenant les contacts et projets de l'utilisateur.
@@ -199,6 +205,12 @@ Tu as accès à une mémoire persistante contenant les contacts et projets de l'
 
     DEFAULT_SYSTEM_PROMPT_NO_PROFILE = """Tu es THÉRÈSE, une assistante IA souveraine française.
 Tu aides les entrepreneurs et TPE avec leurs tâches quotidiennes.
+
+## Style de réponse
+- Réponds de manière concise et directe. Va droit au but.
+- N'utilise PAS de tableaux markdown sauf si l'utilisateur le demande explicitement.
+- Privilégie les listes à puces ou le texte simple pour les récapitulatifs.
+- Pas d'emojis de statut, pas de dashboards non sollicités.
 {therese_md}"""
 
     def __init__(self, config: LLMConfig | None = None):

--- a/src/backend/app/services/skills/code_executor.py
+++ b/src/backend/app/services/skills/code_executor.py
@@ -227,6 +227,10 @@ def repair_truncated_code(code: str) -> str | None:
     Tente de réparer du code Python tronqué en retirant les lignes
     incomplètes à la fin jusqu'à obtenir un code syntaxiquement valide.
 
+    Si la réparation supprime l'appel .save(output_path), celui-ci est
+    rajouté automatiquement en détectant le nom de la variable du document
+    (wb, doc, prs, document, workbook, presentation).
+
     Args:
         code: Code Python potentiellement tronqué
 
@@ -254,11 +258,52 @@ def repair_truncated_code(code: str) -> str | None:
                 removed,
                 len(lines),
             )
+            # Ajouter .save(output_path) si absent après réparation
+            candidate = _ensure_save_call(candidate)
             return candidate
         except SyntaxError:
             continue
 
     return None
+
+
+def _ensure_save_call(code: str) -> str:
+    """
+    Vérifie que le code contient un appel .save(output_path).
+    Si absent, détecte le nom de la variable du document et l'ajoute.
+
+    Args:
+        code: Code Python syntaxiquement valide
+
+    Returns:
+        Code avec .save(output_path) garanti
+    """
+    if ".save(output_path)" in code:
+        return code
+
+    # Détecter le nom de la variable du document principal
+    # Patterns courants : wb = Workbook(), doc = Document(), prs = Presentation()
+    doc_var = None
+    for pattern in [
+        r"(\w+)\s*=\s*Workbook\s*\(",
+        r"(\w+)\s*=\s*Document\s*\(",
+        r"(\w+)\s*=\s*Presentation\s*\(",
+    ]:
+        match = re.search(pattern, code)
+        if match:
+            doc_var = match.group(1)
+            break
+
+    if doc_var:
+        save_line = f"\n{doc_var}.save(output_path)\n"
+        logger.warning(
+            "Appel .save(output_path) manquant après réparation, "
+            "ajout automatique : %s.save(output_path)",
+            doc_var,
+        )
+        return code + save_line
+
+    return code
 
 
 def validate_code(code: str) -> tuple[bool, str]:
@@ -624,6 +669,10 @@ class CodeGenSkill(BaseSkill):
                 '.save(output_path)',
                 code,
             )
+
+            # Ajouter .save(output_path) si absent (code tronqué par max_tokens
+            # mais syntaxiquement valide, donc pas réparé par repair_truncated_code)
+            code = _ensure_save_call(code)
 
             try:
                 logger.info(

--- a/src/frontend/src/components/settings/LLMTab.tsx
+++ b/src/frontend/src/components/settings/LLMTab.tsx
@@ -451,10 +451,10 @@ export function LLMTab({
           <select
             value={selectedModel}
             onChange={(e) => onSelectModel(e.target.value)}
-            className="w-full px-4 py-2.5 bg-background/60 border border-border/50 rounded-lg text-sm text-text focus:outline-none focus:border-accent-cyan/50 transition-colors"
+            className="w-full px-4 py-2.5 bg-background/60 border border-border/50 rounded-lg text-sm text-text focus:outline-none focus:border-accent-cyan/50 transition-colors [&>option]:bg-[var(--color-surface)] [&>option]:text-[var(--color-text)]"
           >
             {availableModels.map((model) => (
-              <option key={model.id} value={model.id}>
+              <option key={model.id} value={model.id} className="bg-[var(--color-surface)] text-[var(--color-text)]">
                 {model.name} {model.badge ? `(${model.badge})` : ''}
               </option>
             ))}

--- a/src/frontend/src/services/api/chat.ts
+++ b/src/frontend/src/services/api/chat.ts
@@ -105,13 +105,15 @@ export async function sendMessage(req: ChatRequest): Promise<ChatResponse> {
 
 // Chat - Streaming (SSE)
 export async function* streamMessage(
-  req: ChatRequest
+  req: ChatRequest,
+  signal?: AbortSignal,
 ): AsyncGenerator<StreamChunk> {
   const url = `${API_BASE}/api/chat/send`;
   const response = await apiFetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ ...req, stream: true }),
+    signal,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Correctif batch v0.2.6

**5 bugs corrigés dans cette PR :**

### BUG-025 : Ollama /api/chat 404
- **Cause :** Le provider envoyait un champ `system` top-level à `/api/chat` (n'existe que sur `/api/generate`). De plus, un trailing slash sur base_url pouvait créer un double slash dans l'URL.
- **Solution :** System prompt inséré comme message `role: "system"` dans le tableau messages. `rstrip("/")` sur base_url.

### BUG-036 : XLSX code tronqué (fichier vide)
- **Cause :** Quand le LLM génère du code tronqué par max_tokens, `repair_truncated_code()` retire les lignes invalides mais perd `wb.save(output_path)`.
- **Solution :** Nouvelle fonction `_ensure_save_call()` qui détecte la variable document (wb/doc/prs) et ajoute `.save(output_path)` si absent.

### Contraste dropdown modèle (cosmétique)
- **Cause :** Les `<option>` du select modèle héritaient mal les couleurs en thème sombre.
- **Solution :** Classes CSS explicites `bg-[var(--color-surface)] text-[var(--color-text)]` sur les options.

### BUG-038 : Bouton stop streaming
- **Cause :** Aucun moyen d'interrompre une réponse en cours.
- **Solution :** AbortController dans ChatInput, bouton Stop (carré rouge) remplace Send pendant le streaming, texte partiel conservé à l'interruption.

### UX : Réponses trop lourdes
- **Cause :** THÉRÈSE générait des tableaux markdown et emojis de statut non demandés.
- **Solution :** System prompt enrichi avec instructions anti-tableaux, pro-listes à puces, anti-emojis.

## Tests
- [x] 13 tests de régression ajoutés (134 total, tous passent)
- [x] 89 tests frontend OK (8 fichiers)
- [x] ruff lint OK
- [x] Challenger : APPROUVÉ (1 itération)

## Fichiers modifiés
- `src/backend/app/services/providers/ollama.py`
- `src/backend/app/services/skills/code_executor.py`
- `src/backend/app/services/llm.py`
- `src/frontend/src/components/chat/ChatInput.tsx`
- `src/frontend/src/components/settings/LLMTab.tsx`
- `src/frontend/src/services/api/chat.ts`
- `tests/test_regression.py`