### PR TITLE
fix: BUG-039 bouton email + BUG-040 DOCX page blanche (démo)

### DIFF
--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1744,3 +1744,54 @@ class TestStreamingRawText:
         assert "minHeight" in content, (
             "MessageBubble doit calculer un minHeight dynamique pendant le streaming"
         )
+
+
+# ─── BUG-039 Bouton email dans MessageBubble ──────────────────────────────
+
+class TestBUG039_EmailButton:
+    """MessageBubble doit avoir un bouton pour envoyer par email."""
+
+    MSG_BUBBLE = Path("src/frontend/src/components/chat/MessageBubble.tsx")
+
+    def test_mail_icon_imported(self):
+        """L'icône Mail doit être importée de lucide-react."""
+        content = self.MSG_BUBBLE.read_text(encoding="utf-8")
+        assert "Mail" in content, "L'icône Mail doit être importée"
+
+    def test_mailto_link(self):
+        """Le bouton email doit ouvrir un lien mailto:."""
+        content = self.MSG_BUBBLE.read_text(encoding="utf-8")
+        assert "mailto:" in content, "Le bouton email doit utiliser un lien mailto:"
+
+    def test_open_in_mail_client_function(self):
+        """La fonction openInMailClient doit exister."""
+        content = self.MSG_BUBBLE.read_text(encoding="utf-8")
+        assert "openInMailClient" in content, (
+            "MessageBubble doit avoir une fonction openInMailClient"
+        )
+
+
+# ─── BUG-040 DOCX page blanche (code tronqué) ────────────────────────────
+
+class TestBUG040_DocxTruncatedCode:
+    """Le code DOCX tronqué doit être réparé avec ajout de .save()."""
+
+    def test_ensure_save_call_detects_document(self):
+        """_ensure_save_call doit détecter Document() et ajouter .save()."""
+        from app.services.skills.code_executor import _ensure_save_call
+
+        code = 'doc = Document()\ndoc.add_heading("Test", level=0)'
+        result = _ensure_save_call(code)
+        assert ".save(output_path)" in result, (
+            "_ensure_save_call doit ajouter doc.save(output_path) pour Document()"
+        )
+
+    def test_ensure_save_call_detects_presentation(self):
+        """_ensure_save_call doit détecter Presentation() et ajouter .save()."""
+        from app.services.skills.code_executor import _ensure_save_call
+
+        code = 'prs = Presentation()\nslide = prs.slides.add_slide(prs.slide_layouts[0])'
+        result = _ensure_save_call(code)
+        assert ".save(output_path)" in result, (
+            "_ensure_save_call doit ajouter prs.save(output_path) pour Presentation()"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -3136,7 +3136,7 @@ wheels = [
 
 [[package]]
 name = "therese-backend"
-version = "0.2.3"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Correctif urgent - Bugs de démo (17 fév)

Bugs survenus en démo devant 30 personnes. Priorité critique.

### BUG-039 : Messagerie - pas d'action après génération d'email
- **Cause :** Le skill email-pro génère du texte dans le chat mais aucun bouton ne permettait d'envoyer l'email ensuite.
- **Solution :** Ajout d'un bouton "Envoyer par email" (icône Mail) dans MessageBubble. Ouvre le client mail natif via Tauri `shell.open()` avec un lien `mailto:?body=...`. Fallback `window.open()` si Tauri non disponible.

### BUG-040 : DOCX page blanche avec Claude Opus 4.6
- **Cause :** Le code python-docx généré par Opus 4.6 dépasse max_tokens et est tronqué. L'appel `doc.save(output_path)` est perdu. Le fichier n'est jamais sauvegardé, le fallback legacy crée un document quasi vide.
- **Solution :** Ajout de `_ensure_save_call()` dans code_executor.py qui détecte automatiquement la variable document (Workbook/Document/Presentation) et ajoute `.save(output_path)` si absent. Couvre XLSX, DOCX et PPTX.

## Tests
- [x] 5 tests de régression ajoutés (126 total)
- [x] 89 tests frontend OK
- [x] ruff lint OK

## Fichiers modifiés
- `src/backend/app/services/skills/code_executor.py`
- `src/frontend/src/components/chat/MessageBubble.tsx`
- `tests/test_regression.py`

**Note :** Cette PR peut être mergée indépendamment de la PR #6 (pas de conflit). Si PR #6 est mergée en premier, il faudra résoudre le conflit trivial sur code_executor.py (même code ajouté aux deux endroits).