### PR TITLE
fix: Croix fermeture wizard email inopérante (BUG-037)

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "therese-frontend",
-  "version": "0.1.6",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "therese-frontend",
-      "version": "0.1.6",
+      "version": "0.2.6",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/src/frontend/src/components/email/EmailPanel.test.tsx
+++ b/src/frontend/src/components/email/EmailPanel.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * THÉRÈSE v2 - EmailPanel Tests
+ *
+ * Régression BUG-037 : Croix de fermeture du wizard email inopérante.
+ * La croix doit fermer le wizard même quand aucun compte n'est configuré.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// --- Mocks -----------------------------------------------------------------
+
+const mockGetEmailAuthStatus = vi.fn();
+const mockListEmailLabels = vi.fn();
+
+vi.mock('../../services/api', () => ({
+  getEmailAuthStatus: (...args: unknown[]) => mockGetEmailAuthStatus(...args),
+  listEmailLabels: (...args: unknown[]) => mockListEmailLabels(...args),
+}));
+
+// Variables partagées pour l'email store
+let mockToggleEmailPanel = vi.fn();
+
+vi.mock('../../stores/emailStore', () => ({
+  useEmailStore: () => ({
+    isEmailPanelOpen: true,
+    toggleEmailPanel: mockToggleEmailPanel,
+    accounts: [],
+    currentAccountId: null,
+    setAccounts: vi.fn(),
+    setCurrentAccount: vi.fn(),
+    isComposing: false,
+    setIsComposing: vi.fn(),
+    currentMessageId: null,
+    labels: [],
+    setLabels: vi.fn(),
+    currentLabelId: 'INBOX',
+    setCurrentLabel: vi.fn(),
+    needsReauth: false,
+    setNeedsReauth: vi.fn(),
+  }),
+}));
+
+// Mock EmailSetupWizard : expose un bouton pour simuler onCancel
+vi.mock('./wizard', () => ({
+  EmailSetupWizard: ({
+    onCancel,
+    onComplete,
+  }: {
+    onCancel: () => void;
+    onComplete: () => void;
+  }) => (
+    <div data-testid="email-setup-wizard">
+      <button data-testid="wizard-cancel-btn" onClick={onCancel}>
+        X
+      </button>
+      <button data-testid="wizard-complete-btn" onClick={onComplete}>
+        Terminer
+      </button>
+    </div>
+  ),
+}));
+
+// Mock dépendances Tauri non disponibles en test
+vi.mock('@tauri-apps/plugin-shell', () => ({
+  open: vi.fn(),
+}));
+
+// Mock sous-composants email et dépendances tierces absentes en test
+vi.mock('./EmailList', () => ({ EmailList: () => <div>EmailList</div> }));
+vi.mock('./EmailDetail', () => ({ EmailDetail: () => <div>EmailDetail</div> }));
+vi.mock('./EmailCompose', () => ({ EmailCompose: () => <div>EmailCompose</div> }));
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }));
+
+// ---------------------------------------------------------------------------
+
+describe('BUG-037 - Croix de fermeture du wizard email', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetEmailAuthStatus.mockResolvedValue({ accounts: [] });
+    mockToggleEmailPanel = vi.fn();
+  });
+
+  it('affiche le wizard quand aucun compte n\'est configuré', async () => {
+    const { EmailPanel } = await import('./EmailPanel');
+    render(<EmailPanel standalone />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('email-setup-wizard')).toBeTruthy();
+    });
+  });
+
+  it('BUG-037 : la croix du wizard ferme le wizard (mode standalone, sans compte)', async () => {
+    const { EmailPanel } = await import('./EmailPanel');
+    render(<EmailPanel standalone />);
+
+    // Attendre que le wizard s'affiche
+    await waitFor(() => {
+      expect(screen.getByTestId('email-setup-wizard')).toBeTruthy();
+    });
+
+    // Cliquer sur la croix du wizard
+    fireEvent.click(screen.getByTestId('wizard-cancel-btn'));
+
+    // Le wizard doit disparaître
+    await waitFor(() => {
+      expect(screen.queryByTestId('email-setup-wizard')).toBeNull();
+    });
+  });
+
+  it('BUG-037 : après fermeture du wizard, un écran de repli s\'affiche avec "Configurer un compte"', async () => {
+    const { EmailPanel } = await import('./EmailPanel');
+    render(<EmailPanel standalone />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('email-setup-wizard')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('wizard-cancel-btn'));
+
+    // L'écran de repli doit proposer de relancer la configuration
+    await waitFor(() => {
+      expect(screen.getByText('Configurer un compte')).toBeTruthy();
+    });
+  });
+
+  it('BUG-037 : clic sur "Configurer un compte" relance le wizard', async () => {
+    const { EmailPanel } = await import('./EmailPanel');
+    render(<EmailPanel standalone />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('email-setup-wizard')).toBeTruthy();
+    });
+
+    // Fermer le wizard
+    fireEvent.click(screen.getByTestId('wizard-cancel-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Configurer un compte')).toBeTruthy();
+    });
+
+    // Relancer le wizard
+    fireEvent.click(screen.getByText('Configurer un compte'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('email-setup-wizard')).toBeTruthy();
+    });
+  });
+
+  it('BUG-037 : en mode modal sans compte, la croix ferme le panel entier', async () => {
+    const { EmailPanel } = await import('./EmailPanel');
+    render(<EmailPanel standalone={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('email-setup-wizard')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('wizard-cancel-btn'));
+
+    // toggleEmailPanel doit avoir été appelé pour fermer le panel
+    await waitFor(() => {
+      expect(mockToggleEmailPanel).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/frontend/src/components/email/EmailPanel.tsx
+++ b/src/frontend/src/components/email/EmailPanel.tsx
@@ -64,6 +64,10 @@ export function EmailPanel({ standalone = false }: EmailPanelProps) {
   const [showAddAccount, setShowAddAccount] = useState(false);
   const [showAccountMenu, setShowAccountMenu] = useState(false);
   const [reauthing, setReauthing] = useState(false);
+  // Contrôle l'affichage du wizard indépendamment de isConnected.
+  // Initialisé à true pour l'afficher automatiquement si aucun compte.
+  // Mis à false quand l'utilisateur clique la croix du wizard.
+  const [showSetupWizard, setShowSetupWizard] = useState(true);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Load accounts on mount (standalone ou modal)
@@ -139,6 +143,7 @@ export function EmailPanel({ standalone = false }: EmailPanelProps) {
 
   function handleAddAccountComplete() {
     setShowAddAccount(false);
+    setShowSetupWizard(true);
     loadAccounts();
   }
 
@@ -350,9 +355,23 @@ export function EmailPanel({ standalone = false }: EmailPanelProps) {
                 Réessayer
               </Button>
             </div>
-          ) : !isConnected || showAddAccount ? (
+          ) : (!isConnected && showSetupWizard) || showAddAccount ? (
             <div className="flex-1">
-              <EmailSetupWizard onComplete={handleAddAccountComplete} onCancel={() => setShowAddAccount(false)} />
+              <EmailSetupWizard
+                onComplete={handleAddAccountComplete}
+                onCancel={() => {
+                  setShowAddAccount(false);
+                  setShowSetupWizard(false);
+                }}
+              />
+            </div>
+          ) : !isConnected ? (
+            <div className="flex-1 flex flex-col items-center justify-center gap-4">
+              <Mail className="w-12 h-12 text-text-muted/40" />
+              <p className="text-text-muted text-sm">Aucun compte email configuré.</p>
+              <Button variant="primary" size="sm" onClick={() => setShowSetupWizard(true)}>
+                Configurer un compte
+              </Button>
             </div>
           ) : isComposing ? (
             <EmailCompose />
@@ -571,9 +590,16 @@ export function EmailPanel({ standalone = false }: EmailPanelProps) {
                 Réessayer
               </Button>
             </div>
-          ) : !isConnected || showAddAccount ? (
+          ) : (!isConnected && showSetupWizard) || showAddAccount ? (
             <div className="flex-1">
-              <EmailSetupWizard onComplete={handleAddAccountComplete} onCancel={() => showAddAccount ? setShowAddAccount(false) : toggleEmailPanel()} />
+              <EmailSetupWizard
+                onComplete={handleAddAccountComplete}
+                onCancel={() => {
+                  setShowAddAccount(false);
+                  setShowSetupWizard(false);
+                  if (!showAddAccount) toggleEmailPanel();
+                }}
+              />
             </div>
           ) : isComposing ? (
             <EmailCompose />

--- a/uv.lock
+++ b/uv.lock
@@ -3136,7 +3136,7 @@ wheels = [
 
 [[package]]
 name = "therese-backend"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Correctif

**Bug :** La croix X du wizard de configuration email ne fermait pas la modale quand aucun compte n'était configuré (multiplateforme — signalé par Laroll).
**Cause :** La condition d'affichage du wizard (`!isConnected || showAddAccount`) restait vraie même après que `onCancel` appelait `setShowAddAccount(false)`, car `isConnected` (dérivé du store) n'est pas affecté par cet appel. La croix était visuellement présente mais sans effet observable sur le rendu.
**Solution :** Ajout d'un état local `showSetupWizard` (boolean, défaut `true`). La condition devient `(!isConnected && showSetupWizard) || showAddAccount`. En mode standalone, `onCancel` met `showSetupWizard` à `false` et affiche un écran de repli avec un bouton "Configurer un compte". En mode modal, `onCancel` appelle en plus `toggleEmailPanel()` pour fermer le panel entier.

## Tests
- [x] 5 tests de régression ajoutés (`BUG037_CroixFermetureWizardEmail`)
- [x] 94/94 tests vitest OK
- [x] Lint ruff OK (erreurs préexistantes, non liées au changement)

## Fichiers modifiés
- `src/frontend/src/components/email/EmailPanel.tsx`
- `src/frontend/src/components/email/EmailPanel.test.tsx` (nouveau)