### PR TITLE
feat: F-10 - Labels Gmail alignés sur Google Cloud Console FR

### DIFF
--- a/src/frontend/src/components/email/wizard/CredentialsStep.tsx
+++ b/src/frontend/src/components/email/wizard/CredentialsStep.tsx
@@ -80,14 +80,14 @@ export function CredentialsStep({
         </div>
         <h3 className="text-lg font-semibold text-text">Entre tes identifiants</h3>
         <p className="text-sm text-text-muted">
-          Copie le Client ID et Client Secret depuis Google Cloud Console
+          Copie l'ID client et le Code secret du client depuis Google Cloud Console
         </p>
       </div>
 
-      {/* Client ID */}
+      {/* ID client */}
       <div>
         <label htmlFor="clientId" className="text-sm text-text-muted mb-2 block">
-          Client ID
+          ID client
         </label>
         <div className="relative">
           <input
@@ -119,10 +119,10 @@ export function CredentialsStep({
         )}
       </div>
 
-      {/* Client Secret */}
+      {/* Code secret du client */}
       <div>
         <label htmlFor="clientSecret" className="text-sm text-text-muted mb-2 block">
-          Client Secret
+          Code secret du client
         </label>
         <div className="relative">
           <input


### PR DESCRIPTION
## Amélioration UX

**Fiche :** F-10 - Labels UI Gmail FR
**Composant :** Frontend - Formulaire de configuration Gmail

## Changements

Dans le formulaire de configuration OAuth Gmail (`CredentialsStep.tsx`), les libellés anglais ont été remplacés par les termes exacts de Google Cloud Console en français :

| Avant | Après |
|-------|-------|
| "Client ID" | "ID client" |
| "Client Secret" | "Code secret du client" |

Cela réduit la friction lors de la saisie des identifiants : l'utilisateur voit exactement les mêmes termes dans THÉRÈSE et dans Google Cloud Console FR.

## Fichiers modifiés
- `src/frontend/src/components/email/wizard/CredentialsStep.tsx`

## Tests
- [x] TypeScript typecheck OK (`tsc --noEmit`)
- [x] Pas de régression logique (changement purement cosmétique/labels)