### PR TITLE
fix: BUG-090/093/094/095 - export VCF et régressions backend legacy

### DIFF
--- a/src/backend/app/models/database.py
+++ b/src/backend/app/models/database.py
@@ -28,21 +28,56 @@ async_engine = None
 AsyncSessionLocal = None
 
 
+INVOICE_LEGACY_COLUMN_DEFINITIONS: dict[str, str] = {
+    "currency": "TEXT DEFAULT 'EUR'",
+    "payment_terms": "TEXT",
+    "payment_method": "TEXT",
+    "late_penalty_rate": "REAL",
+    "legal_mentions": "TEXT",
+    "converted_from_id": "TEXT",
+    "validite_jours": "INTEGER",
+    "payment_date": "TIMESTAMP",
+}
+
+
 def ensure_invoice_currency_column(db_path: Path | None) -> bool:
     """Ajoute la colonne invoices.currency si elle manque sur une DB legacy."""
+    return "currency" in ensure_invoice_legacy_columns(db_path, columns=("currency",))
+
+
+def ensure_invoice_legacy_columns(
+    db_path: Path | None,
+    columns: tuple[str, ...] | None = None,
+) -> list[str]:
+    """Ajoute les colonnes invoices manquantes sur une DB legacy."""
     if db_path is None or not db_path.exists():
-        return False
+        return []
+
+    target_columns = columns or tuple(INVOICE_LEGACY_COLUMN_DEFINITIONS.keys())
+    added_columns: list[str] = []
 
     with sqlite3.connect(str(db_path)) as conn:
         cursor = conn.execute("PRAGMA table_info(invoices)")
-        columns = [row[1] for row in cursor.fetchall()]
-        if not columns or "currency" in columns:
-            return False
+        existing_columns = {row[1] for row in cursor.fetchall()}
+        if not existing_columns:
+            return []
 
-        conn.execute("ALTER TABLE invoices ADD COLUMN currency TEXT DEFAULT 'EUR'")
-        conn.commit()
-        logger.info("Migration auto : colonne 'currency' ajoutée à la table invoices")
-        return True
+        for column_name in target_columns:
+            if column_name in existing_columns:
+                continue
+
+            column_definition = INVOICE_LEGACY_COLUMN_DEFINITIONS[column_name]
+            conn.execute(f"ALTER TABLE invoices ADD COLUMN {column_name} {column_definition}")
+            added_columns.append(column_name)
+
+        if added_columns:
+            conn.commit()
+            logger.info(
+                "Migration auto : colonnes invoices ajoutées (%s)",
+                ", ".join(added_columns),
+            )
+
+    return added_columns
 
 
 def get_database_url(async_mode: bool = True) -> str:
@@ -121,7 +156,7 @@ async def init_db() -> None:
     SQLModel.metadata.create_all(sync_engine)
 
     # Auto-migration : ajouter les colonnes manquantes aux tables existantes
-    ensure_invoice_currency_column(settings.db_path)
+    ensure_invoice_legacy_columns(settings.db_path)
 
     with sync_engine.connect() as conn:
         alter_statements = [
@@ -145,6 +180,7 @@ async def init_db() -> None:
             # PERF audit - index sur les FK frequemment filtrees
             "CREATE INDEX IF NOT EXISTS ix_tasks_project_id ON tasks (project_id)",
             "CREATE INDEX IF NOT EXISTS ix_invoice_lines_invoice_id ON invoice_lines (invoice_id)",
+            "CREATE INDEX IF NOT EXISTS ix_invoices_converted_from_id ON invoices (converted_from_id)",
             "CREATE INDEX IF NOT EXISTS ix_activities_contact_id ON activities (contact_id)",
             "CREATE INDEX IF NOT EXISTS ix_deliverables_project_id ON deliverables (project_id)",
             "CREATE INDEX IF NOT EXISTS ix_calendar_events_calendar_id ON calendar_events (calendar_id)",

--- a/src/backend/app/routers/email.py
+++ b/src/backend/app/routers/email.py
@@ -1147,13 +1147,22 @@ async def list_labels(
             smtp_use_tls=account.smtp_use_tls,
         )
         folders = await provider.list_folders()
+
+        def _get_folder_counter(folder, primary_attr: str, fallback_attr: str) -> int:
+            primary_value = getattr(folder, primary_attr, None)
+            if type(primary_value) is int:
+                return primary_value
+
+            fallback_value = getattr(folder, fallback_attr, 0)
+            return fallback_value if type(fallback_value) is int else 0
+
         return [
             {
                 "id": f.id,
                 "name": f.name,
                 "type": f.type,
-                "messagesTotal": f.messages_total,
-                "messagesUnread": f.messages_unread,
+                "messagesTotal": _get_folder_counter(f, "message_count", "messages_total"),
+                "messagesUnread": _get_folder_counter(f, "unread_count", "messages_unread"),
             }
             for f in folders
         ]

--- a/src/backend/app/services/providers/openrouter.py
+++ b/src/backend/app/services/providers/openrouter.py
@@ -169,13 +169,15 @@ class OpenRouterProvider(BaseProvider):
                         except json.JSONDecodeError:
                             continue
 
-        except httpx.HTTPStatusError as e:
+        except httpx.HTTPStatusError as http_error:
+            response = http_error.response
+            status = response.status_code
             error_body = ""
             try:
-                error_body = e.response.text
+                error_body = response.text
             except Exception as body_err:
                 logger.debug("Impossible de lire le body erreur OpenRouter: %s", body_err)
-            logger.error(f"OpenRouter API error: {e.response.status_code} - {error_body}")
+            logger.error(f"OpenRouter API error: {status} - {error_body}")
 
             # BUG-openrouter-403 : parser le body JSON pour un message d'erreur lisible
             api_error_msg = ""
@@ -189,7 +191,6 @@ class OpenRouterProvider(BaseProvider):
             # Borne la longueur pour éviter de flooder l'UI avec un message très long
             api_error_msg = api_error_msg[:200]
 
-            status = e.response.status_code
             if status == 401:
                 yield StreamEvent(type="error", content="Clé API OpenRouter invalide ou expirée.")
             elif status == 402:

--- a/src/frontend/src/components/memory/MemoryPanel.test.tsx
+++ b/src/frontend/src/components/memory/MemoryPanel.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryPanel } from './MemoryPanel';
+import { useStatusStore } from '../../stores/statusStore';
+
+const mockDownloadVCFFile = vi.fn();
+const mockListContactsWithScope = vi.fn();
+const mockListFiles = vi.fn();
+const mockGetRGPDStats = vi.fn();
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual<typeof import('../../services/api')>('../../services/api');
+  return {
+    ...actual,
+    downloadVCFFile: (...args: unknown[]) => mockDownloadVCFFile(...args),
+    listContactsWithScope: (...args: unknown[]) => mockListContactsWithScope(...args),
+    listFiles: (...args: unknown[]) => mockListFiles(...args),
+    getRGPDStats: (...args: unknown[]) => mockGetRGPDStats(...args),
+  };
+});
+
+vi.mock('../../hooks', () => ({
+  useDemoMask: () => ({
+    enabled: false,
+    maskContact: (contact: unknown) => contact,
+    populateMap: vi.fn(),
+  }),
+}));
+
+vi.mock('../files/FileBrowser', () => ({
+  FileBrowser: () => <div data-testid="file-browser" />,
+}));
+
+describe('MemoryPanel export VCF', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+    mockListContactsWithScope.mockResolvedValue([]);
+    mockListFiles.mockResolvedValue([]);
+    mockGetRGPDStats.mockResolvedValue(null);
+    useStatusStore.setState({ notifications: [] });
+  });
+
+  it('affiche un succès desktop quand l export est réellement sauvegardé', async () => {
+    mockDownloadVCFFile.mockResolvedValue('desktop_saved');
+
+    render(<MemoryPanel isOpen onClose={vi.fn()} />);
+
+    fireEvent.click(await screen.findByTitle('Exporter les contacts (.vcf)'));
+
+    await waitFor(() => {
+      expect(useStatusStore.getState().notifications).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'success',
+            title: 'Export VCF',
+            message: 'Contacts exportés dans Téléchargements',
+          }),
+        ])
+      );
+    });
+  });
+
+  it('affiche un succès web quand le téléchargement navigateur démarre', async () => {
+    mockDownloadVCFFile.mockResolvedValue('browser_download_started');
+
+    render(<MemoryPanel isOpen onClose={vi.fn()} />);
+
+    fireEvent.click(await screen.findByTitle('Exporter les contacts (.vcf)'));
+
+    await waitFor(() => {
+      expect(useStatusStore.getState().notifications).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'success',
+            title: 'Export VCF',
+            message: 'Téléchargement du fichier VCF démarré',
+          }),
+        ])
+      );
+    });
+  });
+
+  it('affiche une erreur visible si l export échoue', async () => {
+    mockDownloadVCFFile.mockRejectedValue(new Error('disk full'));
+
+    render(<MemoryPanel isOpen onClose={vi.fn()} />);
+
+    fireEvent.click(await screen.findByTitle('Exporter les contacts (.vcf)'));
+
+    await waitFor(() => {
+      expect(useStatusStore.getState().notifications).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'error',
+            title: 'Erreur export VCF',
+            message: 'disk full',
+          }),
+        ])
+      );
+    });
+  });
+});

--- a/src/frontend/src/components/memory/MemoryPanel.tsx
+++ b/src/frontend/src/components/memory/MemoryPanel.tsx
@@ -7,6 +7,7 @@ import { FileBrowser } from '../files/FileBrowser';
 import * as api from '../../services/api';
 import type { MemoryScope, RGPDStatsResponse } from '../../services/api';
 import { useDemoMask } from '../../hooks';
+import { useStatusStore } from '../../stores/statusStore';
 import { Z_LAYER } from '../../styles/z-layers';
 
 interface MemoryPanelProps {
@@ -19,6 +20,7 @@ interface MemoryPanelProps {
 type Tab = 'contacts' | 'files';
 
 export function MemoryPanel({ isOpen, onClose, onNewContact, onEditContact }: MemoryPanelProps) {
+  const addNotification = useStatusStore((state) => state.addNotification);
   const [activeTab, setActiveTab] = useState<Tab>('contacts');
   const [contacts, setContacts] = useState<api.Contact[]>([]);
   const [indexedFiles, setIndexedFiles] = useState<api.FileMetadata[]>([]);
@@ -58,16 +60,21 @@ export function MemoryPanel({ isOpen, onClose, onNewContact, onEditContact }: Me
 
   async function handleExportVCF() {
     try {
-      const blob = await api.exportVCFFile();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'therese-contacts.vcf';
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      const result = await api.downloadVCFFile();
+      addNotification({
+        type: 'success',
+        title: 'Export VCF',
+        message:
+          result === 'desktop_saved'
+            ? 'Contacts exportés dans Téléchargements'
+            : 'Téléchargement du fichier VCF démarré',
+      });
     } catch (err: any) {
+      addNotification({
+        type: 'error',
+        title: 'Erreur export VCF',
+        message: err.message,
+      });
       alert('Erreur export VCF : ' + err.message);
     }
   }
@@ -562,7 +569,7 @@ export function MemoryPanel({ isOpen, onClose, onNewContact, onEditContact }: Me
                     title="Importer des contacts (.vcf)"
                   >
                     <Upload className="w-4 h-4 mr-2" />
-                    Importer
+                    Importer VCF
                   </Button>
                   <input
                     ref={(el) => { vcfInputRef.current = el; }}
@@ -578,7 +585,7 @@ export function MemoryPanel({ isOpen, onClose, onNewContact, onEditContact }: Me
                     title="Exporter les contacts (.vcf)"
                   >
                     <Download className="w-4 h-4 mr-2" />
-                    Exporter
+                    Exporter VCF
                   </Button>
                 </div>
               </div>

--- a/src/frontend/src/services/api/index.ts
+++ b/src/frontend/src/services/api/index.ts
@@ -69,6 +69,8 @@ export {
   searchMemory,
   importVCFFile,
   exportVCFFile,
+  downloadVCFFile,
+  type VCFDownloadResult,
   type Contact,
   type Project,
   type MemoryScope,

--- a/src/frontend/src/services/api/memory.test.ts
+++ b/src/frontend/src/services/api/memory.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { downloadDir } from '@tauri-apps/api/path';
+import { exists, writeFile } from '@tauri-apps/plugin-fs';
+
+const mockApiFetch = vi.fn();
+
+vi.mock('./core', async () => {
+  const actual = await vi.importActual<typeof import('./core')>('./core');
+  return {
+    ...actual,
+    API_BASE: 'http://127.0.0.1:17293',
+    apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+  };
+});
+
+import { downloadVCFFile } from './memory';
+
+describe('downloadVCFFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete (window as unknown as { __TAURI__?: boolean }).__TAURI__;
+    vi.mocked(downloadDir).mockResolvedValue('/home/test/Downloads');
+    vi.mocked(exists).mockResolvedValue(false);
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+  });
+
+  it('écrit le VCF dans Téléchargements en runtime Tauri', async () => {
+    (window as unknown as { __TAURI__: boolean }).__TAURI__ = true;
+
+    mockApiFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ 'Content-Disposition': 'attachment; filename="therese-contacts.vcf"' }),
+      blob: () => Promise.resolve({
+        arrayBuffer: async () => new TextEncoder().encode('BEGIN:VCARD\nFN:Test').buffer,
+      }),
+    });
+
+    await expect(downloadVCFFile()).resolves.toBe('desktop_saved');
+    expect(writeFile).toHaveBeenCalledWith(
+      '/home/test/Downloads/therese-contacts.vcf',
+      expect.any(Uint8Array)
+    );
+  });
+
+  it('évite d écraser un export existant dans Téléchargements', async () => {
+    (window as unknown as { __TAURI__: boolean }).__TAURI__ = true;
+    vi.mocked(exists)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    mockApiFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ 'Content-Disposition': 'attachment; filename="therese-contacts.vcf"' }),
+      blob: () => Promise.resolve({
+        arrayBuffer: async () => new TextEncoder().encode('BEGIN:VCARD\nFN:Test').buffer,
+      }),
+    });
+
+    await expect(downloadVCFFile()).resolves.toBe('desktop_saved');
+    expect(writeFile).toHaveBeenCalledWith(
+      '/home/test/Downloads/therese-contacts-2.vcf',
+      expect.any(Uint8Array)
+    );
+  });
+
+  it('propage une erreur visible si l écriture Tauri échoue sans fallback web', async () => {
+    (window as unknown as { __TAURI__: boolean }).__TAURI__ = true;
+    vi.mocked(writeFile).mockRejectedValueOnce(new Error('disk full'));
+    const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL');
+
+    mockApiFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers(),
+      blob: () => Promise.resolve({
+        arrayBuffer: async () => new TextEncoder().encode('BEGIN:VCARD').buffer,
+      }),
+    });
+
+    await expect(downloadVCFFile()).rejects.toThrow('disk full');
+    expect(createObjectURLSpy).not.toHaveBeenCalled();
+
+    createObjectURLSpy.mockRestore();
+  });
+
+  it('démarre un téléchargement navigateur hors runtime Tauri', async () => {
+    const blob = new Blob(['BEGIN:VCARD\nFN:Test'], { type: 'text/vcard' });
+    const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:vcf');
+    const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+
+    mockApiFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ 'Content-Disposition': 'attachment; filename="therese-contacts.vcf"' }),
+      blob: () => Promise.resolve(blob),
+    });
+
+    await expect(downloadVCFFile()).resolves.toBe('browser_download_started');
+    expect(createObjectURLSpy).toHaveBeenCalledWith(blob);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:vcf');
+
+    clickSpy.mockRestore();
+    revokeObjectURLSpy.mockRestore();
+    createObjectURLSpy.mockRestore();
+  });
+
+  it('remonte une ApiError quand l export backend échoue', async () => {
+    mockApiFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () => Promise.resolve({ detail: 'backend cassé' }),
+    });
+
+    await expect(downloadVCFFile()).rejects.toEqual(
+      expect.objectContaining({
+        name: 'ApiError',
+        message: 'backend cassé',
+      })
+    );
+  });
+});

--- a/src/frontend/src/services/api/memory.ts
+++ b/src/frontend/src/services/api/memory.ts
@@ -5,7 +5,7 @@
  * Sprint 2 - PERF-2.2: Extracted from monolithic api.ts
  */
 
-import { request } from './core';
+import { ApiError, request } from './core';
 
 // Types
 export interface Contact {
@@ -250,4 +250,75 @@ export async function exportVCFFile(): Promise<Blob> {
     throw new Error(d.detail || d.message || `Erreur ${response.status}`);
   }
   return response.blob();
+}
+
+export type VCFDownloadResult = 'desktop_saved' | 'browser_download_started';
+
+function getVCFFilenameFromDisposition(disposition: string | null): string {
+  if (!disposition) {
+    return 'therese-contacts.vcf';
+  }
+
+  const match = disposition.match(/filename="?([^";\n]+)"?/);
+  return match?.[1] || 'therese-contacts.vcf';
+}
+
+function buildVCFVariantFilename(filename: string, index: number): string {
+  const dotIndex = filename.lastIndexOf('.');
+  if (dotIndex <= 0) {
+    return `${filename}-${index}`;
+  }
+
+  const base = filename.slice(0, dotIndex);
+  const extension = filename.slice(dotIndex);
+  return `${base}-${index}${extension}`;
+}
+
+async function saveVCFFileInDownloads(blob: Blob, filename: string): Promise<void> {
+  const [{ downloadDir, join }, { exists, writeFile }] = await Promise.all([
+    import('@tauri-apps/api/path'),
+    import('@tauri-apps/plugin-fs'),
+  ]);
+
+  const downloadsPath = await downloadDir();
+  let candidateFilename = filename;
+  let targetPath = await join(downloadsPath, candidateFilename);
+  let suffix = 2;
+
+  while (await exists(targetPath)) {
+    candidateFilename = buildVCFVariantFilename(filename, suffix);
+    targetPath = await join(downloadsPath, candidateFilename);
+    suffix += 1;
+  }
+
+  const arrayBuffer = await blob.arrayBuffer();
+  await writeFile(targetPath, new Uint8Array(arrayBuffer));
+}
+
+export async function downloadVCFFile(): Promise<VCFDownloadResult> {
+  const { API_BASE, apiFetch } = await import('./core');
+  const response = await apiFetch(`${API_BASE}/api/memory/contacts/export`);
+  if (!response.ok) {
+    const d = await response.json().catch(() => ({}));
+    throw new ApiError(response.status, response.statusText, d.detail || d.message || `Erreur ${response.status}`);
+  }
+
+  const filename = getVCFFilenameFromDisposition(response.headers.get('Content-Disposition'));
+  const blob = await response.blob();
+  const isTauriRuntime = typeof window !== 'undefined' && ('__TAURI__' in window || '__TAURI_INTERNALS__' in window);
+
+  if (isTauriRuntime) {
+    await saveVCFFileInDownloads(blob, filename);
+    return 'desktop_saved';
+  }
+
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+  return 'browser_download_started';
 }

--- a/src/frontend/src/test/setup.ts
+++ b/src/frontend/src/test/setup.ts
@@ -9,11 +9,27 @@ vi.mock('@tauri-apps/api/event', () => ({
 
 vi.mock('@tauri-apps/plugin-dialog', () => ({
   open: vi.fn(),
+  save: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/path', () => ({
+  downloadDir: vi.fn(),
+  homeDir: vi.fn(),
+  join: vi.fn((...parts: string[]) => parts.join('/')),
+  resolve: vi.fn((...parts: string[]) => parts.join('/')),
 }));
 
 vi.mock('@tauri-apps/plugin-fs', () => ({
+  exists: vi.fn(),
+  readDir: vi.fn(),
   readFile: vi.fn(),
   readTextFile: vi.fn(),
+  stat: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/plugin-shell', () => ({
+  open: vi.fn(),
 }));
 
 // Mock fetch for API calls

--- a/tests/test_invoice_currency_migration.py
+++ b/tests/test_invoice_currency_migration.py
@@ -2,7 +2,7 @@ import sqlite3
 from pathlib import Path
 
 import pytest
-from app.models.database import ensure_invoice_currency_column
+from app.models.database import ensure_invoice_currency_column, ensure_invoice_legacy_columns
 
 
 @pytest.mark.parametrize("with_invoices_table", [True, False])
@@ -75,3 +75,103 @@ def test_ensure_invoice_currency_column_is_idempotent(tmp_path: Path):
 
     assert first is False
     assert second is False
+
+
+def test_ensure_invoice_legacy_columns_adds_missing_invoice_fields(tmp_path: Path):
+    db_path = tmp_path / "legacy-therese.db"
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE invoices (
+                id TEXT PRIMARY KEY,
+                invoice_number TEXT NOT NULL,
+                contact_id TEXT NOT NULL,
+                issue_date TEXT NOT NULL,
+                due_date TEXT NOT NULL,
+                status TEXT NOT NULL,
+                subtotal_ht REAL NOT NULL DEFAULT 0,
+                total_tax REAL NOT NULL DEFAULT 0,
+                total_ttc REAL NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                currency TEXT DEFAULT 'EUR'
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO invoices VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "inv-1",
+                "FACT-2026-001",
+                "contact-1",
+                "2026-03-14T00:00:00",
+                "2026-03-30T00:00:00",
+                "draft",
+                100.0,
+                20.0,
+                120.0,
+                "2026-03-14T00:00:00",
+                "2026-03-14T00:00:00",
+                "EUR",
+            ),
+        )
+        conn.commit()
+
+    added_columns = ensure_invoice_legacy_columns(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(invoices)").fetchall()}
+        for expected in {
+            "payment_terms",
+            "payment_method",
+            "late_penalty_rate",
+            "legal_mentions",
+            "converted_from_id",
+            "validite_jours",
+            "payment_date",
+        }:
+            assert expected in columns
+
+        row = conn.execute(
+            "SELECT payment_terms, payment_method, late_penalty_rate, validite_jours FROM invoices WHERE id = 'inv-1'"
+        ).fetchone()
+        assert row == (None, None, None, None)
+
+    assert set(added_columns) >= {
+        "payment_terms",
+        "payment_method",
+        "late_penalty_rate",
+        "legal_mentions",
+        "converted_from_id",
+        "validite_jours",
+        "payment_date",
+    }
+
+
+def test_ensure_invoice_legacy_columns_is_idempotent(tmp_path: Path):
+    db_path = tmp_path / "legacy-therese.db"
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE invoices (
+                id TEXT PRIMARY KEY,
+                currency TEXT DEFAULT 'EUR',
+                payment_terms TEXT,
+                payment_method TEXT,
+                late_penalty_rate REAL,
+                legal_mentions TEXT,
+                converted_from_id TEXT,
+                validite_jours INTEGER,
+                payment_date TIMESTAMP
+            )
+            """
+        )
+        conn.commit()
+
+    first = ensure_invoice_legacy_columns(db_path)
+    second = ensure_invoice_legacy_columns(db_path)
+
+    assert first == []
+    assert second == []

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -4423,6 +4423,38 @@ class TestBUGOpenRouter403MessageErreur:
         assert err_event.type == "error"
         assert "invalid" in (err_event.content or "").lower() or "invalide" in (err_event.content or "").lower() or "clé" in (err_event.content or "").lower()
 
+    def test_openrouter_429_rate_limit_message_without_unboundlocalerror(self):
+        """Une 429 doit rester lisible et ne jamais se transformer en UnboundLocalError."""
+        import asyncio
+        from unittest.mock import MagicMock, patch
+        import httpx
+
+        provider = self._make_provider()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.text = '{"error":{"message":"Rate limit exceeded"}}'
+        error = httpx.HTTPStatusError("429 Too Many Requests", request=MagicMock(), response=mock_response)
+
+        async def run():
+            with patch.object(provider.client, "stream", side_effect=error):
+                events = []
+                async for event in provider.stream(None, [{"role": "user", "content": "test"}]):
+                    events.append(event)
+                return events
+
+        events = asyncio.new_event_loop().run_until_complete(run())
+        assert events, "Une 429 doit produire un événement d erreur exploitable"
+        err_event = events[0]
+        assert err_event.type == "error"
+        msg = err_event.content or ""
+        assert "trop de requêtes" in msg.lower() or "429" in msg, (
+            f"Message 429 non informatif : {msg!r}"
+        )
+        assert "unboundlocalerror" not in msg.lower(), (
+            f"La 429 ne doit plus être masquée par une erreur locale : {msg!r}"
+        )
+
 
 # ============================================================
 # BUG-091 - Séparateur décimal dans InvoiceForm
@@ -5235,15 +5267,14 @@ class TestBUG69NestedExceptShadowing:
     la variable de l outer HTTPStatusError handler, provoquant UnboundLocalError."""
 
     def test_openrouter_no_nested_except_as_e_in_http_error_handler(self):
-        """Le bloc except httpx.HTTPStatusError as e ne doit pas contenir
-        un nested 'except Exception as e:' qui ecrase la variable."""
+        """Le bloc HTTPStatusError ne doit pas réutiliser `e` dans un nested except."""
         import re
         from pathlib import Path
 
         src_file = Path(__file__).parent.parent / "src" / "backend" / "app" / "services" / "providers" / "openrouter.py"
         src = src_file.read_text()
         match = re.search(
-            r"except httpx\.HTTPStatusError as e:.*?(?=\n\s*except [A-Z])",
+            r"except httpx\.HTTPStatusError as \w+:.*?(?=\n\s*except [A-Z])",
             src,
             re.DOTALL,
         )
@@ -5251,7 +5282,7 @@ class TestBUG69NestedExceptShadowing:
         block = match.group(0)
         assert "except Exception as e:" not in block, (
             "Nested 'except Exception as e:' dans le handler HTTPStatusError "
-            "ecrase la variable e (bug local variable e). Utiliser un autre nom."
+            "réintroduit le bug local variable e. Utiliser un autre nom."
         )
 
     def test_anthropic_no_nested_except_as_e_in_http_error_handler(self):
@@ -5380,3 +5411,30 @@ class TestBUG69OllamaFallbackRespectsProvider:
             assert service.config.api_key is None, (
                 "api_key doit etre None pour laisser l appel API echouer proprement"
             )
+
+
+class TestBUG090VCFExport:
+    """Export VCF visible et compatible avec les scopes Tauri desktop."""
+
+    def test_memory_api_uses_downloads_scope_for_tauri_export(self):
+        """Le helper VCF desktop doit écrire dans Téléchargements, pas un chemin arbitraire."""
+        content = (FRONTEND / "services" / "api" / "memory.ts").read_text(encoding="utf-8")
+        assert "downloadDir" in content, (
+            "downloadVCFFile() doit résoudre le dossier Téléchargements en runtime Tauri"
+        )
+        assert "saveVCFFileInDownloads" in content, (
+            "downloadVCFFile() doit utiliser un helper dédié pour l écriture desktop"
+        )
+        assert "writeFile(targetPath" in content, (
+            "Le VCF doit être écrit explicitement via writeFile() dans un chemin autorisé"
+        )
+
+    def test_memory_panel_uses_download_helper_for_visible_export(self):
+        """MemoryPanel doit passer par le helper desktop et notifier le succès."""
+        content = (FRONTEND / "components" / "memory" / "MemoryPanel.tsx").read_text(encoding="utf-8")
+        assert "await api.downloadVCFFile()" in content, (
+            "MemoryPanel doit utiliser downloadVCFFile() plutôt qu un blob URL direct"
+        )
+        assert "Contacts exportés dans Téléchargements" in content, (
+            "Le succès doit indiquer à l utilisateur où retrouver le fichier exporté"
+        )


### PR DESCRIPTION
## Bugs corrigés (batch nuit Zézette du 29/04)

| Bug | Problème | Correctif |
|-----|----------|-----------|
| **BUG-090** | Export VCF invisible sous Tauri desktop (blob URL fragile) | Sauvegarde fiable + message distinct desktop/web |
| **BUG-093** | Erreur 429 OpenRouter masquée | Extraction locale sûre de la réponse HTTP (variable d'exception protégée du shadowing) |
| **BUG-094** | Bases SQLite legacy avec colonnes invoices manquantes | Auto-migration des colonnes + tests dédiés |
| **BUG-095** | Sérialisation email désalignée (anciens noms d'attributs) | Fallback strict sur compteurs réels ou legacy |

## Stats

- **11 fichiers modifiés**, +557/-32 lignes
- **~290 lignes de tests ajoutés** (`MemoryPanel.test.tsx`, `memory.test.ts`, extension de `test_invoice_currency_migration.py` et `test_regression.py`)

## Tests régression (lancés avant ouverture PR)

- **Backend pytest** : 853 passed, 3 failed (préexistants sur main, non liés à cette PR), 64 deselected (réseau/MCP)
- **Frontend vitest** : 121/121 passed (16 test files, 9.13s)
- **Total : 974 tests, 0 régression introduite**

## Dette technique préexistante (à traiter séparément)

3 failures héritées de v0.11.5 :
- `test_modal_z_index_above_email_panel` : `ResponseGeneratorModal` n'a plus `z-[60]`
- `test_higher_z_index` : `EmailSetupWizard` n'a plus `z-[70]`
- `test_no_hardcoded_localhost_in_components` : `UpdateBanner.tsx` contient des URLs localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)