### PR TITLE
fix: BUG-096/097 - encodage Unicode + insertion résultat action dans chat

### DIFF
--- a/src/frontend/src/components/invoices/InvoiceForm.tsx
+++ b/src/frontend/src/components/invoices/InvoiceForm.tsx
@@ -34,17 +34,17 @@ const TVA_RATES = [
 ];
 
 const CURRENCIES = [
-  { value: 'EUR', label: 'EUR (\u20ac)' },
+  { value: 'EUR', label: 'EUR (€)' },
   { value: 'CHF', label: 'CHF' },
   { value: 'USD', label: 'USD ($)' },
-  { value: 'GBP', label: 'GBP (\u00a3)' },
+  { value: 'GBP', label: 'GBP (£)' },
 ];
 
 const CURRENCY_SYMBOLS: Record<string, string> = {
-  EUR: '\u20ac',
+  EUR: '€',
   CHF: 'CHF',
   USD: '$',
-  GBP: '\u00a3',
+  GBP: '£',
 };
 
 function formatDecimalInput(value: number) {
@@ -413,22 +413,22 @@ export function InvoiceForm({ invoice, onClose, onSave }: InvoiceFormProps) {
                 )}
               >
                 <option value="draft">Brouillon</option>
-                <option value="sent">Envoy\u00e9</option>
+                <option value="sent">Envoyé</option>
                 {documentType === 'devis' ? (
                   <>
-                    <option value="accepted">Accept\u00e9</option>
-                    <option value="refused">Refus\u00e9</option>
-                    <option value="expired">Expir\u00e9</option>
+                    <option value="accepted">Accepté</option>
+                    <option value="refused">Refusé</option>
+                    <option value="expired">Expiré</option>
                     <option value="converted">Converti en facture</option>
                   </>
                 ) : (
                   <>
-                    <option value="accepted">Accept\u00e9</option>
-                    <option value="paid">Pay\u00e9e</option>
+                    <option value="accepted">Accepté</option>
+                    <option value="paid">Payée</option>
                     <option value="overdue">En retard</option>
                   </>
                 )}
-                <option value="cancelled">Annul\u00e9e</option>
+                <option value="cancelled">Annulée</option>
               </select>
             </div>
 
@@ -476,7 +476,7 @@ export function InvoiceForm({ invoice, onClose, onSave }: InvoiceFormProps) {
 
             <div>
               <label htmlFor="dueDate" className="block text-sm font-medium text-text mb-2">
-                Date d'\u00e9ch\u00e9ance *
+                Date d'échéance *
               </label>
               <input
                 type="date"
@@ -496,7 +496,7 @@ export function InvoiceForm({ invoice, onClose, onSave }: InvoiceFormProps) {
             {documentType === 'devis' && (
               <div>
                 <label htmlFor="validiteJours" className="block text-sm font-medium text-text mb-2">
-                  Validit\u00e9 (jours)
+                  Validité (jours)
                 </label>
                 <input
                   type="number"
@@ -710,7 +710,7 @@ export function InvoiceForm({ invoice, onClose, onSave }: InvoiceFormProps) {
                 onClick={handleMarkPaid}
                 className="px-4 py-2 rounded-lg bg-green-500/20 text-green-500 hover:bg-green-500/30 transition-colors"
               >
-                Marquer comme pay\u00e9e
+                Marquer comme payée
               </button>
             )}
 
@@ -721,7 +721,7 @@ export function InvoiceForm({ invoice, onClose, onSave }: InvoiceFormProps) {
                   onClick={async () => {
                     try {
                       const updated = await updateDevisStatus(invoice.id, 'accepted');
-                      addNotification({ type: 'success', title: 'Devis accept\u00e9', message: invoice.invoice_number });
+                      addNotification({ type: 'success', title: 'Devis accepté', message: invoice.invoice_number });
                       onSave(updated);
                     } catch (err) {
                       addNotification({ type: 'error', title: 'Erreur', message: String(err) });
@@ -736,7 +736,7 @@ export function InvoiceForm({ invoice, onClose, onSave }: InvoiceFormProps) {
                   onClick={async () => {
                     try {
                       const updated = await updateDevisStatus(invoice.id, 'refused');
-                      addNotification({ type: 'success', title: 'Devis refus\u00e9', message: invoice.invoice_number });
+                      addNotification({ type: 'success', title: 'Devis refusé', message: invoice.invoice_number });
                       onSave(updated);
                     } catch (err) {
                       addNotification({ type: 'error', title: 'Erreur', message: String(err) });

--- a/src/frontend/src/components/invoices/InvoicesPanel.tsx
+++ b/src/frontend/src/components/invoices/InvoicesPanel.tsx
@@ -312,10 +312,10 @@ export function InvoicesPanel({ standalone = false }: InvoicesPanelProps) {
                     </div>
 
                     <div className="text-sm text-text-muted space-y-1">
-                      <p>{invoice.document_type === 'devis' ? '\u00c9mis' : '\u00c9mise'} le {new Date(invoice.issue_date).toLocaleDateString('fr-FR')}</p>
-                      <p>\u00c9ch\u00e9ance le {new Date(invoice.due_date).toLocaleDateString('fr-FR')}</p>
+                      <p>{invoice.document_type === 'devis' ? 'Émis' : 'Émise'} le {new Date(invoice.issue_date).toLocaleDateString('fr-FR')}</p>
+                      <p>Échéance le {new Date(invoice.due_date).toLocaleDateString('fr-FR')}</p>
                       {invoice.document_type === 'devis' && invoice.validite_jours && (
-                        <p>Validit\u00e9 : {invoice.validite_jours} jours</p>
+                        <p>Validité : {invoice.validite_jours} jours</p>
                       )}
                       {invoice.payment_date && (
                         <p>Payée le {new Date(invoice.payment_date).toLocaleDateString('fr-FR')}</p>

--- a/src/frontend/src/components/prompts/PromptLibrary.tsx
+++ b/src/frontend/src/components/prompts/PromptLibrary.tsx
@@ -1,7 +1,7 @@
 /**
- * TH\u00c9R\u00c8SE - Biblioth\u00e8que de prompts pr\u00eats \u00e0 l'emploi
+ * THÉRÈSE - Bibliothèque de prompts prêts à l'emploi
  *
- * Affiche les prompts class\u00e9s par cat\u00e9gorie avec accord\u00e9ons,
+ * Affiche les prompts classés par catégorie avec accordéons,
  * recherche et insertion dans le ChatInput.
  */
 
@@ -15,7 +15,7 @@ import {
   type PromptCategory,
   type PromptItem,
 } from '../../services/api';
-// SVG inline pour les ic\u00f4nes de cat\u00e9gories (jamais d'emoji)
+// SVG inline pour les icônes de catégories (jamais d'emoji)
 const CATEGORY_ICONS: Record<string, React.JSX.Element> = {
   email: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5">
@@ -176,7 +176,7 @@ function PromptCard({
                   onSelect(prompt);
                 }}
               >
-                Ins\u00e9rer dans le chat
+                Insérer dans le chat
               </Button>
             </div>
           </motion.div>
@@ -187,7 +187,7 @@ function PromptCard({
 }
 
 /**
- * Accord\u00e9on de cat\u00e9gorie.
+ * Accordéon de catégorie.
  */
 function CategoryAccordion({
   category,
@@ -244,12 +244,12 @@ function CategoryAccordion({
 }
 
 /**
- * Composant principal : Biblioth\u00e8que de prompts.
+ * Composant principal : Bibliothèque de prompts.
  */
 export interface PromptLibraryProps {
-  /** Appel\u00e9 quand l'utilisateur s\u00e9lectionne un prompt. */
+  /** Appelé quand l'utilisateur sélectionne un prompt. */
   onSelectPrompt: (promptText: string) => void;
-  /** Appel\u00e9 pour fermer la biblioth\u00e8que. */
+  /** Appelé pour fermer la bibliothèque. */
   onClose: () => void;
 }
 
@@ -271,7 +271,7 @@ export function PromptLibrary({ onSelectPrompt, onClose }: PromptLibraryProps) {
         setLoading(false);
       })
       .catch((err) => {
-        setError(err.message || 'Impossible de charger la biblioth\u00e8que');
+        setError(err.message || 'Impossible de charger la bibliothèque');
         setLoading(false);
       });
   }, []);
@@ -308,7 +308,7 @@ export function PromptLibrary({ onSelectPrompt, onClose }: PromptLibraryProps) {
     }, 300);
   }, []);
 
-  // S\u00e9lection d'un prompt
+  // Sélection d'un prompt
   const handleSelect = useCallback(
     (prompt: PromptItem) => {
       onSelectPrompt(prompt.prompt);
@@ -337,13 +337,13 @@ export function PromptLibrary({ onSelectPrompt, onClose }: PromptLibraryProps) {
           <ArrowLeft className="w-5 h-5" />
         </button>
         <div className="flex-1">
-          <h2 className="text-lg font-semibold text-text">Biblioth\u00e8que de prompts</h2>
+          <h2 className="text-lg font-semibold text-text">Bibliothèque de prompts</h2>
           <p className="text-xs text-text-muted mt-0.5">
             {loading
               ? 'Chargement...'
               : searchResults !== null
-                ? `${totalResults} r\u00e9sultat${totalResults !== 1 ? 's' : ''} pour "${searchQuery}"`
-                : `${categories.reduce((acc, c) => acc + c.prompts.length, 0)} prompts pr\u00eats \u00e0 l'emploi`}
+                ? `${totalResults} résultat${totalResults !== 1 ? 's' : ''} pour "${searchQuery}"`
+                : `${categories.reduce((acc, c) => acc + c.prompts.length, 0)} prompts prêts à l'emploi`}
           </p>
         </div>
       </div>
@@ -386,7 +386,7 @@ export function PromptLibrary({ onSelectPrompt, onClose }: PromptLibraryProps) {
               className="mt-4"
               onClick={() => window.location.reload()}
             >
-              R\u00e9essayer
+              Réessayer
             </Button>
           </div>
         ) : displayedCategories.length === 0 ? (
@@ -394,15 +394,15 @@ export function PromptLibrary({ onSelectPrompt, onClose }: PromptLibraryProps) {
             {searchQuery.trim() ? (
               <>
                 <p className="text-sm text-text-muted">
-                  Aucun prompt trouv\u00e9 pour "{searchQuery}"
+                  Aucun prompt trouvé pour "{searchQuery}"
                 </p>
                 <p className="text-xs text-text-muted/60 mt-1">
-                  Essaie avec d'autres mots-cl\u00e9s
+                  Essaie avec d'autres mots-clés
                 </p>
               </>
             ) : (
               <p className="text-sm text-text-muted">
-                La biblioth\u00e8que de prompts est vide ou indisponible.
+                La bibliothèque de prompts est vide ou indisponible.
               </p>
             )}
           </div>

--- a/src/frontend/src/services/api/prompts.ts
+++ b/src/frontend/src/services/api/prompts.ts
@@ -1,7 +1,7 @@
 /**
- * TH\u00c9R\u00c8SE - API Biblioth\u00e8que de prompts
+ * THÉRÈSE - API Bibliothèque de prompts
  *
- * Service d'acc\u00e8s \u00e0 la biblioth\u00e8que de prompts pr\u00eats \u00e0 l'emploi.
+ * Service d'accès à la bibliothèque de prompts prêts à l'emploi.
  */
 
 import { request } from './core';
@@ -33,14 +33,14 @@ export interface PromptSearchResponse {
 }
 
 /**
- * R\u00e9cup\u00e8re la biblioth\u00e8que compl\u00e8te group\u00e9e par cat\u00e9gorie.
+ * Récupère la bibliothèque complète groupée par catégorie.
  */
 export async function getPromptLibrary(): Promise<PromptLibraryResponse> {
   return request<PromptLibraryResponse>('/api/prompts/library');
 }
 
 /**
- * Recherche dans la biblioth\u00e8que par mots-cl\u00e9s.
+ * Recherche dans la bibliothèque par mots-clés.
  */
 export async function searchPromptLibrary(query: string): Promise<PromptSearchResponse> {
   return request<PromptSearchResponse>(

--- a/src/frontend/src/stores/actionsStore.ts
+++ b/src/frontend/src/stores/actionsStore.ts
@@ -15,17 +15,38 @@ import {
 import { useChatStore } from './chatStore';
 
 /**
+ * Set d'idempotence : empeche d'inserer plusieurs fois le resultat
+ * d'une meme tache (defense en profondeur contre les re-poll concurrents
+ * ou un futur re-fetch de taches historiques).
+ */
+const insertedTaskIds = new Set<string>();
+
+/**
  * Insere le resultat d'une action terminee dans le chat actif.
  * BUG-097 (Smileshoot) : l'UI annoncait "Resultat insere dans le chat"
  * mais aucun code ne realisait l'insertion.
+ *
+ * Pour status `completed` : insere le resultat avec header agent.
+ * Pour status `error` : insere un message d'erreur clair (resultat
+ * partiel inclus s'il existe).
  */
 function insertResultInChat(task: TaskState): void {
-  if (!task.result?.trim()) return;
+  if (insertedTaskIds.has(task.task_id)) return;
+
   const header = task.agent_name ? `**${task.agent_name}**\n\n` : '';
-  useChatStore.getState().addMessage({
-    role: 'assistant',
-    content: `${header}${task.result}`,
-  });
+  let content: string | null = null;
+
+  if (task.status === 'completed' && task.result?.trim()) {
+    content = `${header}${task.result}`;
+  } else if (task.status === 'error') {
+    const partial = task.result?.trim() ? `\n\n${task.result}` : '';
+    const errMsg = task.error?.trim() || 'tache echouee';
+    content = `${header}Erreur : ${errMsg}${partial}`;
+  }
+
+  if (!content) return;
+  insertedTaskIds.add(task.task_id);
+  useChatStore.getState().addMessage({ role: 'assistant', content });
 }
 
 interface ActionsState {
@@ -132,8 +153,12 @@ export const useActionsStore = create<ActionsState>((set, get) => ({
           state.activeTask?.task_id === taskId ? updated : state.activeTask,
       }));
 
-      // BUG-097 : transition vers completed -> injecter le resultat dans le chat
-      if (previous?.status !== 'completed' && updated.status === 'completed') {
+      // BUG-097 : transition vers completed ou error -> injecter dans le chat
+      // Le Set insertedTaskIds garantit l'idempotence (pas de doublon)
+      const becameFinal =
+        previous?.status !== updated.status &&
+        (updated.status === 'completed' || updated.status === 'error');
+      if (becameFinal) {
         insertResultInChat(updated);
       }
     } catch {

--- a/src/frontend/src/stores/actionsStore.ts
+++ b/src/frontend/src/stores/actionsStore.ts
@@ -12,6 +12,21 @@ import {
   fetchTask,
   cancelTask,
 } from '../services/api/actions';
+import { useChatStore } from './chatStore';
+
+/**
+ * Insere le resultat d'une action terminee dans le chat actif.
+ * BUG-097 (Smileshoot) : l'UI annoncait "Resultat insere dans le chat"
+ * mais aucun code ne realisait l'insertion.
+ */
+function insertResultInChat(task: TaskState): void {
+  if (!task.result?.trim()) return;
+  const header = task.agent_name ? `**${task.agent_name}**\n\n` : '';
+  useChatStore.getState().addMessage({
+    role: 'assistant',
+    content: `${header}${task.result}`,
+  });
+}
 
 interface ActionsState {
   /** Liste des agents disponibles */
@@ -109,11 +124,18 @@ export const useActionsStore = create<ActionsState>((set, get) => ({
   refreshTask: async (taskId) => {
     try {
       const updated = await fetchTask(taskId);
+      const previous = get().tasks.find((t) => t.task_id === taskId);
+
       set((state) => ({
         tasks: state.tasks.map((t) => (t.task_id === taskId ? updated : t)),
         activeTask:
           state.activeTask?.task_id === taskId ? updated : state.activeTask,
       }));
+
+      // BUG-097 : transition vers completed -> injecter le resultat dans le chat
+      if (previous?.status !== 'completed' && updated.status === 'completed') {
+        insertResultInChat(updated);
+      }
     } catch {
       // Silencieux en cas d'erreur de polling
     }

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -5438,3 +5438,46 @@ class TestBUG090VCFExport:
         assert "Contacts exportés dans Téléchargements" in content, (
             "Le succès doit indiquer à l utilisateur où retrouver le fichier exporté"
         )
+
+    def test_no_unicode_escape_in_jsx_text_nodes(self):
+        """
+        BUG-096 (Smileshoot, v0.11.6) : `\\u00XX` en littéral dans du JSX text node
+        s'affiche tel quel ("Pay\\u00e9e" au lieu de "Payée") car JSX ne décode pas
+        les échappements JS entre les balises. Aucun fichier frontend ne doit
+        contenir de séquence `\\u00XX` (couvre les caractères latin-1 accentués).
+        """
+        import re
+
+        pattern = re.compile(r"\\u00[0-9a-fA-F]{2}")
+        offenders: list[str] = []
+        for path in FRONTEND.rglob("*"):
+            if path.suffix not in {".ts", ".tsx"}:
+                continue
+            if path.name.endswith(".test.ts") or path.name.endswith(".test.tsx"):
+                # Les tests peuvent légitimement contenir des chaînes \\u00XX
+                continue
+            text = path.read_text(encoding="utf-8")
+            if pattern.search(text):
+                offenders.append(str(path.relative_to(FRONTEND)))
+        assert not offenders, (
+            "Caractères Unicode échappés (\\u00XX) trouvés dans : "
+            f"{offenders}. Remplacer par leurs caractères UTF-8 réels."
+        )
+
+    def test_actions_store_inserts_result_in_chat_on_completion(self):
+        """
+        BUG-097 (Smileshoot, v0.11.6) : ActionPanel affichait "Resultat insere
+        dans le chat" mais aucun code ne réalisait l'insertion. Le store
+        actionsStore doit importer chatStore et appeler addMessage() quand
+        une tâche transite vers status `completed`.
+        """
+        content = (FRONTEND / "stores" / "actionsStore.ts").read_text(encoding="utf-8")
+        assert "from './chatStore'" in content or 'from "./chatStore"' in content, (
+            "actionsStore doit importer useChatStore pour insérer le résultat"
+        )
+        assert "useChatStore.getState().addMessage" in content, (
+            "actionsStore doit appeler addMessage() sur transition vers completed"
+        )
+        assert "BUG-097" in content, (
+            "Le fix doit être commenté BUG-097 pour faciliter la traçabilité"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -3170,7 +3170,7 @@ wheels = [
 
 [[package]]
 name = "therese-backend"
-version = "0.10.7"
+version = "0.11.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Bugs corrigés (remontés par Smileshoot sur Discord #bugs le 10/05)

| Bug | Symptôme | Cause | Correctif |
|-----|----------|-------|-----------|
| **BUG-096** | Modules facturation : boutons "Marquer comme payée", labels "Envoyé", etc. (Windows v0.11.6, plusieurs statuts) | 66 séquences `\u00xx` littérales dans 4 fichiers TS/TSX. En JSX text node, JS ne décode pas les échappements → affichage brut | Conversion totale en UTF-8 réel via script Python |
| **BUG-097** | Action multi-étapes : étapes passent en success, note "Resultat insere dans le chat", mais rien n'apparaît dans le chat | `actionsStore.refreshTask()` n'appelait jamais `chatStore.addMessage()` lors de la transition vers `completed`. UI mensongère | Import `useChatStore`, helper `insertResultInChat()` appelé sur transition `running → completed` |

## Fichiers modifiés

- `src/frontend/src/components/invoices/InvoiceForm.tsx` (17 escapes → UTF-8)
- `src/frontend/src/components/invoices/InvoicesPanel.tsx` (5 escapes → UTF-8)
- `src/frontend/src/components/prompts/PromptLibrary.tsx` (28 escapes → UTF-8)
- `src/frontend/src/services/api/prompts.ts` (16 escapes → UTF-8)
- `src/frontend/src/stores/actionsStore.ts` (import chatStore + helper + appel sur transition)
- `tests/test_regression.py` (+2 tests de régression : `test_no_unicode_escape_in_jsx_text_nodes`, `test_actions_store_inserts_result_in_chat_on_completion`)
- `uv.lock` (rattrapage version backend 0.10.7 → 0.11.6)

## Tests de régression

- **Backend pytest** : 855 passed (+2 vs v0.11.6), 3 failed **préexistants identiques** (z-index modal/wizard, localhost UpdateBanner.tsx)
- **Frontend vitest** : 121/121 passed (16 test files, 2.11s)
- **Total : 976 tests, 0 nouvelle régression**

## Backlog Smileshoot non traité ici

- **S1 (suggestions)** : filtres tâches par tags / par projets → backlog produit
- **S2 (suggestions)** : OAuth Google blocage Gmail (Thérèse détectée comme un OpenClaw) → chantier stratégique (process Google verification 4-6 semaines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)