### PR TITLE
fix(chat): commandes / déterministes + déduplication CRM (anti-création en masse)

### DIFF
--- a/src/backend/app/routers/chat.py
+++ b/src/backend/app/routers/chat.py
@@ -43,6 +43,7 @@ from app.services.path_security import validate_file_path
 from app.services.performance import get_performance_monitor, get_search_index
 from app.services.qdrant import get_qdrant_service
 from app.services.skills.base import SkillExecuteRequest
+from app.services.slash_commands import execute_slash_command, parse_slash_command
 from app.services.token_tracker import detect_uncertainty, get_token_tracker
 from app.services.web_search import (
     BROWSER_TOOL,
@@ -561,6 +562,53 @@ async def send_message(
     )
     session.add(user_message)
     await session.commit()
+
+    # Court-circuit deterministe : /contact, /projet, /rdv s'executent en CRUD
+    # direct, sans LLM ni boucle d'outils (regression #bugs-21052026 : creation
+    # de projets EN MASSE via interpretation LLM des commandes /).
+    parsed_cmd = parse_slash_command(request.message)
+    if parsed_cmd is not None:
+        cmd_name, cmd_rest = parsed_cmd
+        confirmation = await execute_slash_command(cmd_name, cmd_rest, session)
+        assistant_message = Message(
+            conversation_id=conversation.id,
+            role="assistant",
+            content=confirmation,
+            model="commande-deterministe",
+        )
+        session.add(assistant_message)
+        await session.commit()
+
+        if request.stream:
+            async def _command_stream() -> AsyncGenerator[str, None]:
+                text_chunk = StreamChunk(
+                    type="text", content=confirmation, conversation_id=conversation.id
+                )
+                yield f"data: {json.dumps(text_chunk.model_dump())}\n\n"
+                done_chunk = StreamChunk(
+                    type="done",
+                    content="",
+                    conversation_id=conversation.id,
+                    message_id=assistant_message.id,
+                )
+                yield f"data: {json.dumps(done_chunk.model_dump())}\n\n"
+
+            return StreamingResponse(
+                _command_stream(),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "X-Accel-Buffering": "no",
+                },
+            )
+
+        return ChatResponse(
+            id=assistant_message.id,
+            conversation_id=conversation.id,
+            content=confirmation,
+            created_at=assistant_message.created_at,
+        )
 
     # Handle streaming response
     if request.stream:

--- a/src/backend/app/services/memory_tools.py
+++ b/src/backend/app/services/memory_tools.py
@@ -12,7 +12,9 @@ from typing import Any
 
 from app.models.entities import Contact, Project
 from app.services.qdrant import get_qdrant_service
+from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +28,10 @@ CREATE_CONTACT_TOOL = {
     "function": {
         "name": "create_contact",
         "description": (
-            "Cree un nouveau contact dans la memoire de THERESE. "
-            "Utilise cet outil quand l'utilisateur mentionne une nouvelle personne "
-            "et souhaite l'enregistrer comme contact."
+            "Cree un contact dans la memoire de THERESE (ou le reutilise s'il existe deja). "
+            "Utilise cet outil UNE SEULE FOIS par personne mentionnee. "
+            "Ne cree jamais de doublon : si le contact existe deja, il est reutilise automatiquement. "
+            "Le nom de famille est optionnel."
         ),
         "parameters": {
             "type": "object",
@@ -62,7 +65,7 @@ CREATE_CONTACT_TOOL = {
                     "description": "Notes supplementaires sur le contact (optionnel)",
                 },
             },
-            "required": ["first_name", "last_name"],
+            "required": ["first_name"],
         },
     },
 }
@@ -72,9 +75,9 @@ CREATE_PROJECT_TOOL = {
     "function": {
         "name": "create_project",
         "description": (
-            "Cree un nouveau projet dans la memoire de THERESE. "
-            "Utilise cet outil quand l'utilisateur mentionne un nouveau projet "
-            "et souhaite l'enregistrer."
+            "Cree un projet dans la memoire de THERESE (ou le reutilise s'il existe deja). "
+            "Utilise cet outil UNE SEULE FOIS par projet mentionne. "
+            "Ne cree jamais de doublon : si un projet du meme nom existe deja, il est reutilise."
         ),
         "parameters": {
             "type": "object",
@@ -106,6 +109,47 @@ MEMORY_TOOLS = [CREATE_CONTACT_TOOL, CREATE_PROJECT_TOOL]
 
 
 # ============================================================
+# Deduplication helpers (anti creation en masse)
+# ============================================================
+
+async def _find_existing_project(session: AsyncSession, name: str) -> Project | None:
+    """Retourne un projet existant de meme nom (insensible casse/espaces)."""
+    norm = name.strip().lower()
+    if not norm:
+        return None
+    result = await session.execute(
+        select(Project).where(func.lower(func.trim(Project.name)) == norm)
+    )
+    return result.scalars().first()
+
+
+async def _find_existing_contact(
+    session: AsyncSession,
+    first_name: str,
+    last_name: str,
+    email: str | None,
+) -> Contact | None:
+    """Retourne un contact existant (par email, sinon par prenom+nom)."""
+    if email:
+        result = await session.execute(
+            select(Contact).where(func.lower(Contact.email) == email.lower())
+        )
+        match = result.scalars().first()
+        if match is not None:
+            return match
+
+    fn = first_name.strip().lower()
+    ln = last_name.strip().lower()
+    if not fn and not ln:
+        return None
+    result = await session.execute(select(Contact))
+    for c in result.scalars().all():
+        if (c.first_name or "").strip().lower() == fn and (c.last_name or "").strip().lower() == ln:
+            return c
+    return None
+
+
+# ============================================================
 # Tool Execution
 # ============================================================
 
@@ -121,19 +165,33 @@ async def execute_create_contact(
     Returns:
         JSON string with the result for the LLM.
     """
-    first_name = arguments.get("first_name", "").strip()
-    last_name = arguments.get("last_name", "").strip()
+    first_name = (arguments.get("first_name") or "").strip()
+    last_name = (arguments.get("last_name") or "").strip()
+    email = (arguments.get("email") or "").strip() or None
 
-    if not first_name or not last_name:
-        return json.dumps({"error": "Prenom et nom requis"}, ensure_ascii=False)
+    # Le nom de famille est optionnel : un prenom (ou une entreprise) suffit.
+    company = (arguments.get("company") or "").strip() or None
+    if not first_name and not last_name and not company:
+        return json.dumps({"error": "Au moins un nom ou une entreprise est requis"}, ensure_ascii=False)
+
+    # Deduplication : si un contact equivalent existe deja, on le reutilise
+    # plutot que de creer un doublon (regression "creation en masse").
+    existing = await _find_existing_contact(session, first_name, last_name, email)
+    if existing is not None:
+        return json.dumps({
+            "success": True,
+            "contact_id": existing.id,
+            "display_name": existing.display_name,
+            "already_existed": True,
+            "message": f"Contact '{existing.display_name}' existe deja, je le reutilise.",
+        }, ensure_ascii=False)
 
     try:
         contact = Contact(
-            first_name=first_name,
-            last_name=last_name,
-            display_name=f"{first_name} {last_name}",
-            company=arguments.get("company"),
-            email=arguments.get("email"),
+            first_name=first_name or None,
+            last_name=last_name or None,
+            company=company,
+            email=email,
             phone=arguments.get("phone"),
             role=arguments.get("role"),
             notes=arguments.get("notes"),
@@ -200,10 +258,22 @@ async def execute_create_project(
     Returns:
         JSON string with the result for the LLM.
     """
-    name = arguments.get("name", "").strip()
+    name = (arguments.get("name") or "").strip()
 
     if not name:
         return json.dumps({"error": "Nom du projet requis"}, ensure_ascii=False)
+
+    # Deduplication : reutilise un projet de meme nom au lieu de creer un doublon
+    # (regression "creation en masse" via les commandes / interpretees par le LLM).
+    existing = await _find_existing_project(session, name)
+    if existing is not None:
+        return json.dumps({
+            "success": True,
+            "project_id": existing.id,
+            "name": existing.name,
+            "already_existed": True,
+            "message": f"Projet '{existing.name}' existe deja, je le reutilise.",
+        }, ensure_ascii=False)
 
     try:
         project = Project(

--- a/src/backend/app/services/slash_commands.py
+++ b/src/backend/app/services/slash_commands.py
@@ -1,0 +1,172 @@
+"""
+THERESE v2 - Commandes slash deterministes (sans LLM).
+
+Regression #bugs-21052026 : /contact, /projet, /rdv passaient par le LLM
+(interpretation non deterministe), qui creait des entites EN MASSE et ne
+respectait pas l'intention. On les execute desormais directement en CRUD,
+sans appel LLM ni boucle d'outils, avec deduplication cote memory_tools.
+
+Syntaxe :
+  /contact Prenom Nom [email=... tel=... societe=... role=...]
+  /projet Nom du projet [budget=1000 statut=active desc=...]
+  /rdv Titre [date=2026-06-03T14:00]
+"""
+
+import json
+import logging
+import re
+from datetime import datetime, timedelta
+
+from app.services.memory_tools import execute_create_contact, execute_create_project
+from app.services.workspace_tools import execute_workspace_tool
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+DETERMINISTIC_COMMANDS = {"contact", "projet", "rdv"}
+
+# Alias de cles -> nom canonique d'argument
+_KEY_ALIASES = {
+    "email": "email", "mail": "email",
+    "tel": "phone", "telephone": "phone", "téléphone": "phone", "phone": "phone",
+    "societe": "company", "société": "company", "company": "company", "entreprise": "company",
+    "role": "role", "rôle": "role", "poste": "role",
+    "budget": "budget",
+    "statut": "status", "status": "status",
+    "desc": "description", "description": "description",
+    "date": "date", "quand": "date",
+}
+
+# Detecte le premier token "cle=" (debut de la zone cle=valeur)
+_KV_HEAD = re.compile(r"[A-Za-zÀ-ÿ]+=", re.UNICODE)
+# Capture chaque paire cle=valeur (valeur jusqu'a la prochaine cle= ou la fin)
+_KV_PAIR = re.compile(r"([A-Za-zÀ-ÿ]+)=(.*?)(?=\s+[A-Za-zÀ-ÿ]+=|$)", re.UNICODE | re.DOTALL)
+
+
+def parse_slash_command(message: str) -> tuple[str, str] | None:
+    """Detecte une commande deterministe en tete de message.
+
+    Retourne (command, rest) si le message commence par une commande connue,
+    sinon None (le message suit alors le flux LLM normal).
+    """
+    if not message:
+        return None
+    stripped = message.lstrip()
+    if not stripped.startswith("/"):
+        return None
+    body = stripped[1:]
+    name, _, rest = body.partition(" ")
+    name = name.strip().lower()
+    if name not in DETERMINISTIC_COMMANDS:
+        return None
+    return name, rest.strip()
+
+
+def _split_positional_and_kwargs(rest: str) -> tuple[str, dict[str, str]]:
+    """Separe le texte positionnel des paires cle=valeur."""
+    head = _KV_HEAD.search(rest)
+    if not head:
+        return rest.strip(), {}
+    positional = rest[: head.start()].strip()
+    kv_part = rest[head.start():]
+    kwargs: dict[str, str] = {}
+    for m in _KV_PAIR.finditer(kv_part):
+        key = m.group(1).strip().lower()
+        val = m.group(2).strip()
+        canon = _KEY_ALIASES.get(key)
+        if canon and val:
+            kwargs[canon] = val
+    return positional, kwargs
+
+
+async def _do_contact(rest: str, session: AsyncSession) -> str:
+    positional, kw = _split_positional_and_kwargs(rest)
+    tokens = positional.split()
+    first_name = tokens[0] if tokens else ""
+    last_name = " ".join(tokens[1:]) if len(tokens) > 1 else ""
+    if not first_name and not kw.get("company"):
+        return "Indique au moins un nom : `/contact Prenom Nom` (ou `/contact Prenom societe=...`)."
+
+    args = {
+        "first_name": first_name,
+        "last_name": last_name,
+        "email": kw.get("email"),
+        "phone": kw.get("phone"),
+        "company": kw.get("company"),
+        "role": kw.get("role"),
+    }
+    result = json.loads(await execute_create_contact(args, session))
+    if result.get("error"):
+        return f"Impossible de creer le contact : {result['error']}"
+    name = result.get("display_name", "contact")
+    if result.get("already_existed"):
+        return f"Contact **{name}** deja en memoire, je le reutilise (pas de doublon)."
+    return f"Contact **{name}** cree en memoire."
+
+
+async def _do_projet(rest: str, session: AsyncSession) -> str:
+    positional, kw = _split_positional_and_kwargs(rest)
+    name = positional.strip()
+    if not name:
+        return "Indique un nom de projet : `/projet Nom du projet [budget=... statut=...]`."
+
+    budget = None
+    if kw.get("budget"):
+        try:
+            budget = float(kw["budget"].replace(",", ".").replace(" ", ""))
+        except ValueError:
+            budget = None
+
+    args = {
+        "name": name,
+        "description": kw.get("description"),
+        "status": kw.get("status", "active"),
+        "budget": budget,
+    }
+    result = json.loads(await execute_create_project(args, session))
+    if result.get("error"):
+        return f"Impossible de creer le projet : {result['error']}"
+    pname = result.get("name", "projet")
+    if result.get("already_existed"):
+        return f"Projet **{pname}** deja en memoire, je le reutilise (pas de doublon)."
+    return f"Projet **{pname}** cree en memoire."
+
+
+async def _do_rdv(rest: str, session: AsyncSession) -> str:
+    positional, kw = _split_positional_and_kwargs(rest)
+    title = positional.strip()
+    if not title:
+        return "Indique un titre : `/rdv Titre date=2026-06-03T14:00`."
+    date_str = kw.get("date")
+    if not date_str:
+        return (
+            "Pour creer un rendez-vous, precise une date au format ISO : "
+            "`/rdv " + title + " date=2026-06-03T14:00`."
+        )
+    try:
+        start = datetime.fromisoformat(date_str)
+    except ValueError:
+        return f"Date invalide : '{date_str}'. Format attendu ISO 8601, ex : 2026-06-03T14:00."
+    end = start + timedelta(hours=1)
+    result = await execute_workspace_tool(
+        "create_calendar_event",
+        {
+            "summary": title,
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+            "description": kw.get("description"),
+        },
+        session,
+    )
+    return result
+
+
+async def execute_slash_command(command: str, rest: str, session: AsyncSession) -> str:
+    """Execute une commande deterministe et retourne le message de confirmation."""
+    if command == "contact":
+        return await _do_contact(rest, session)
+    if command == "projet":
+        return await _do_projet(rest, session)
+    if command == "rdv":
+        return await _do_rdv(rest, session)
+    return f"Commande inconnue : /{command}"

--- a/src/frontend/src/components/chat/SlashCommandsMenu.tsx
+++ b/src/frontend/src/components/chat/SlashCommandsMenu.tsx
@@ -37,14 +37,14 @@ const SLASH_COMMANDS: SlashCommand[] = [
   {
     id: 'contact',
     name: 'contact',
-    description: 'Mentionner ou créer un contact',
+    description: 'Créer un contact : Prénom Nom (email=… tel=…)',
     icon: <UserPlus className="w-4 h-4" />,
     prefix: '/contact ',
   },
   {
     id: 'projet',
     name: 'projet',
-    description: 'Mentionner ou créer un projet',
+    description: 'Créer un projet : Nom (budget=… statut=…)',
     icon: <FolderPlus className="w-4 h-4" />,
     prefix: '/projet ',
   },
@@ -86,7 +86,7 @@ const SLASH_COMMANDS: SlashCommand[] = [
   {
     id: 'rdv',
     name: 'rdv',
-    description: 'Préparer un rendez-vous',
+    description: 'Créer un rendez-vous : Titre (date=2026-06-03T14:00)',
     icon: <Calendar className="w-4 h-4" />,
     prefix: '/rdv ',
   },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,8 +116,10 @@ async def db_session() -> AsyncGenerator[AsyncSession, None]:
     """
     from app.models import database as db_module
 
-    # S'assurer que la DB est initialisée
-    if db_module.AsyncSessionLocal is None:
+    # S'assurer que la DB est initialisée. NB : close_db() (shutdown du lifespan
+    # d'un test HTTP anterieur) remet async_engine a None SANS reinitialiser
+    # AsyncSessionLocal -> on teste les deux pour eviter un async_engine None ici.
+    if db_module.async_engine is None or db_module.AsyncSessionLocal is None:
         await db_module.init_db()
 
     # Créer les tables

--- a/tests/test_memory_tools.py
+++ b/tests/test_memory_tools.py
@@ -1,0 +1,87 @@
+"""
+Tests pour les memory tools (create_contact / create_project).
+
+Regression #bugs-21052026 : les commandes / passaient par le LLM qui creait
+des projets EN MASSE (32 puis 49 doublons) faute de deduplication, et 0 contact
+(last_name obligatoire). Ces tests verrouillent la deduplication et le nom simple.
+"""
+
+import json
+
+import pytest
+from app.models.entities import Contact, Project
+from app.services.memory_tools import execute_create_contact, execute_create_project
+from sqlmodel import select
+
+
+async def _count(session, model) -> int:
+    rows = (await session.execute(select(model))).scalars().all()
+    return len(rows)
+
+
+@pytest.mark.asyncio
+async def test_create_project_dedup_same_name(db_session):
+    """Deux create_project avec le meme nom -> une seule ligne (anti-masse)."""
+    r1 = json.loads(await execute_create_project({"name": "Site Web"}, db_session))
+    r2 = json.loads(await execute_create_project({"name": "Site Web"}, db_session))
+
+    assert r1["success"] is True
+    assert r2["success"] is True
+    assert r2.get("already_existed") is True
+    assert r1["project_id"] == r2["project_id"]
+    assert await _count(db_session, Project) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_project_dedup_case_and_space_insensitive(db_session):
+    """Le nom est compare insensible a la casse et aux espaces."""
+    await execute_create_project({"name": "Projet Alpha"}, db_session)
+    await execute_create_project({"name": "  projet alpha "}, db_session)
+    assert await _count(db_session, Project) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_project_different_names(db_session):
+    """Deux noms differents -> deux projets."""
+    await execute_create_project({"name": "Alpha"}, db_session)
+    await execute_create_project({"name": "Beta"}, db_session)
+    assert await _count(db_session, Project) == 2
+
+
+@pytest.mark.asyncio
+async def test_create_contact_single_name(db_session):
+    """Un prenom seul suffit (last_name optionnel) -> 1 contact cree."""
+    r = json.loads(await execute_create_contact({"first_name": "Jean"}, db_session))
+    assert r["success"] is True
+    assert await _count(db_session, Contact) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_contact_dedup_by_email(db_session):
+    """Meme email -> pas de doublon."""
+    await execute_create_contact(
+        {"first_name": "Jean", "last_name": "Dupont", "email": "jean@x.fr"}, db_session
+    )
+    r2 = json.loads(
+        await execute_create_contact(
+            {"first_name": "Jean", "last_name": "Dupont", "email": "jean@x.fr"}, db_session
+        )
+    )
+    assert r2.get("already_existed") is True
+    assert await _count(db_session, Contact) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_contact_dedup_by_name_case_insensitive(db_session):
+    """Meme nom complet (insensible a la casse) -> pas de doublon."""
+    await execute_create_contact({"first_name": "Marie", "last_name": "Curie"}, db_session)
+    await execute_create_contact({"first_name": "marie", "last_name": "curie"}, db_session)
+    assert await _count(db_session, Contact) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_contact_requires_at_least_a_name(db_session):
+    """Sans aucun nom -> erreur, rien cree."""
+    r = json.loads(await execute_create_contact({}, db_session))
+    assert "error" in r
+    assert await _count(db_session, Contact) == 0

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -1,0 +1,104 @@
+"""
+Tests des commandes slash deterministes (sans LLM).
+
+Verrouille la regression #bugs-21052026 : /contact, /projet, /rdv doivent
+s'executer en CRUD direct, sans LLM, sans creation en masse.
+"""
+
+
+import pytest
+from app.models.entities import Contact, Project
+from app.services.slash_commands import (
+    _split_positional_and_kwargs,
+    execute_slash_command,
+    parse_slash_command,
+)
+from sqlmodel import select
+
+# -------- Detection --------
+
+def test_parse_detects_known_commands():
+    assert parse_slash_command("/contact Jean Dupont") == ("contact", "Jean Dupont")
+    assert parse_slash_command("/projet Refonte site") == ("projet", "Refonte site")
+    assert parse_slash_command("/rdv Point date=2026-06-03T14:00") == (
+        "rdv",
+        "Point date=2026-06-03T14:00",
+    )
+
+
+def test_parse_ignores_non_commands():
+    assert parse_slash_command("Bonjour Therese") is None
+    assert parse_slash_command("/resume") is None  # commande non deterministe
+    assert parse_slash_command("/inconnue truc") is None
+    assert parse_slash_command("") is None
+
+
+# -------- Parsing arguments --------
+
+def test_split_positional_and_kwargs():
+    pos, kw = _split_positional_and_kwargs("Jean Dupont email=jean@x.fr tel=0601 societe=Acme")
+    assert pos == "Jean Dupont"
+    assert kw == {"email": "jean@x.fr", "phone": "0601", "company": "Acme"}
+
+
+def test_split_value_with_spaces():
+    pos, kw = _split_positional_and_kwargs("Refonte site budget=5000 desc=Site vitrine moderne")
+    assert pos == "Refonte site"
+    assert kw["budget"] == "5000"
+    assert kw["description"] == "Site vitrine moderne"
+
+
+def test_split_no_kwargs():
+    pos, kw = _split_positional_and_kwargs("Juste du texte")
+    assert pos == "Juste du texte"
+    assert kw == {}
+
+
+# -------- Execution deterministe --------
+
+@pytest.mark.asyncio
+async def test_contact_command_creates_one(db_session):
+    msg = await execute_slash_command("contact", "Jean Dupont email=jean@x.fr", db_session)
+    assert "Jean Dupont" in msg
+    contacts = (await db_session.execute(select(Contact))).scalars().all()
+    assert len(contacts) == 1
+    assert contacts[0].email == "jean@x.fr"
+
+
+@pytest.mark.asyncio
+async def test_contact_command_no_duplicate(db_session):
+    await execute_slash_command("contact", "Jean Dupont", db_session)
+    msg2 = await execute_slash_command("contact", "Jean Dupont", db_session)
+    assert "deja" in msg2.lower() or "reutilise" in msg2.lower()
+    contacts = (await db_session.execute(select(Contact))).scalars().all()
+    assert len(contacts) == 1
+
+
+@pytest.mark.asyncio
+async def test_projet_command_creates_one_with_budget(db_session):
+    msg = await execute_slash_command("projet", "Refonte site budget=5000 statut=active", db_session)
+    assert "Refonte site" in msg
+    projects = (await db_session.execute(select(Project))).scalars().all()
+    assert len(projects) == 1
+    assert projects[0].budget == 5000.0
+
+
+@pytest.mark.asyncio
+async def test_projet_command_no_mass_creation(db_session):
+    """Le coeur de la regression : N appels du meme projet -> 1 seule ligne."""
+    for _ in range(5):
+        await execute_slash_command("projet", "Site Web", db_session)
+    projects = (await db_session.execute(select(Project))).scalars().all()
+    assert len(projects) == 1
+
+
+@pytest.mark.asyncio
+async def test_rdv_without_date_asks_for_date(db_session):
+    msg = await execute_slash_command("rdv", "Point hebdo", db_session)
+    assert "date" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_rdv_invalid_date(db_session):
+    msg = await execute_slash_command("rdv", "Point date=pas-une-date", db_session)
+    assert "invalide" in msg.lower() or "iso" in msg.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -3170,7 +3170,7 @@ wheels = [
 
 [[package]]
 name = "therese-backend"
-version = "0.11.6"
+version = "0.11.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Bug (Discord alpha, 21/05/2026)

Les commandes `/contact`, `/projet`, `/rdv` n'étaient que des préfixes de texte envoyés au LLM, qui interprétait librement et créait des entités **en masse** (jusqu'à 49 projets en doublon, 0 contact, 0 événement). Signalé par Dr_logic-3D dans #bugs.

## Correctif

- **Déduplication** `create_project` / `create_contact` (par nom insensible à la casse, par email) : renvoie l'existant au lieu de dupliquer. `create_contact` accepte désormais un nom simple (last_name optionnel).
- **Commandes déterministes** : nouveau module `slash_commands.py` (parsing action + `clé=valeur`) + court-circuit dans `send_message` → exécution CRUD directe, **sans LLM ni boucle d'outils**.
- **Frontend** : descriptions des commandes mises à jour avec la syntaxe (`/projet Nom budget=…`).

## Tests

18 nouveaux tests (dédup, nom simple, 5× même projet → 1 ligne, `/rdv` messages clairs). Fix de la fixture `db_session` (bug `async_engine None` après `close_db` d'un test HTTP).

## Note

3 échecs `test_regression.py` (z-index `ResponseGeneratorModal`/`EmailSetupWizard`, localhost `UpdateBanner.tsx`) sont **préexistants sur main**, sans rapport avec ce correctif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
