### PR TITLE
feat(theme): mode clair (Équilibre) par défaut + sombre (Signature) — refonte DA Phase 1

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -40,7 +40,14 @@ function App() {
   // Accessibilite : taille de police et contraste eleve
   const fontSize = useFontSize();
   const highContrast = useAccessibilityStore((state) => state.highContrast);
+  const theme = useAccessibilityStore((state) => state.theme);
   const setReduceMotion = useAccessibilityStore((state) => state.setReduceMotion);
+
+  // Refonte DA : applique le theme clair/sombre sur <html> pour que tout le
+  // document (body, #root, chrome de fenetre) suive les variables de couleur.
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
 
   // US-012 : Detecter la preference systeme reduced-motion au premier lancement
   // et synchroniser avec le store. Ecoute aussi les changements en temps reel.
@@ -166,6 +173,7 @@ function App() {
         className="h-screen w-screen bg-bg text-text overflow-hidden"
         style={{ fontSize }}
         data-testid="app-main"
+        data-theme={theme}
         data-high-contrast={highContrast ? 'true' : undefined}
       >
         <UpdateBanner />

--- a/src/frontend/src/components/actions/ActionPanel.tsx
+++ b/src/frontend/src/components/actions/ActionPanel.tsx
@@ -87,7 +87,7 @@ function AgentCard({
           </p>
           <div className="flex items-center gap-2 mt-2">
             <span className="text-[10px] text-text-muted bg-surface-2 px-2 py-0.5 rounded-full">
-              {agent.steps_count} etapes
+              {agent.steps_count} étapes
             </span>
             <span className={cn('text-[10px] px-2 py-0.5 rounded-full bg-surface-2', colorClass)}>
               {CATEGORY_LABELS[agent.category] || agent.category}
@@ -142,7 +142,7 @@ function ParamsForm({
         </div>
         <div>
           <h3 className="text-sm font-medium text-text">{agent.name}</h3>
-          <p className="text-xs text-text-muted">{agent.steps_count} etapes</p>
+          <p className="text-xs text-text-muted">{agent.steps_count} étapes</p>
         </div>
       </div>
 
@@ -239,8 +239,8 @@ function TaskProgress({
   const statusLabel = {
     pending: 'En attente...',
     running: 'En cours...',
-    completed: 'Termine',
-    cancelled: 'Annule',
+    completed: 'Terminé',
+    cancelled: 'Annulé',
     error: 'Erreur',
   }[task.status];
 
@@ -310,7 +310,7 @@ function TaskProgress({
       {/* Resultat final */}
       {isDone && task.result && (
         <div className="border-t border-border p-4">
-          <p className="text-xs text-text-muted mb-2">Resultat insere dans le chat.</p>
+          <p className="text-xs text-text-muted mb-2">Résultat inséré dans le chat.</p>
         </div>
       )}
     </div>

--- a/src/frontend/src/components/actions/ActionPanel.tsx
+++ b/src/frontend/src/components/actions/ActionPanel.tsx
@@ -63,18 +63,18 @@ function AgentCard({
       onClick={() => onSelect(agent)}
       className={cn(
         'w-full text-left p-4 rounded-xl',
-        'bg-[#131B35]/60 hover:bg-[#1A2340] border border-white/5 hover:border-white/10',
+        'bg-surface/60 hover:bg-surface-elevated border border-border hover:border-border',
         'transition-colors duration-150',
         'group cursor-pointer',
       )}
     >
       <div className="flex items-start gap-3">
-        <div className={cn('p-2 rounded-lg bg-white/5', colorClass)}>
+        <div className={cn('p-2 rounded-lg bg-surface-2', colorClass)}>
           <IconComp size={20} />
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-medium text-white/90 truncate">
+            <h3 className="text-sm font-medium text-text truncate">
               {agent.name}
             </h3>
             <ChevronRight
@@ -86,10 +86,10 @@ function AgentCard({
             {agent.description}
           </p>
           <div className="flex items-center gap-2 mt-2">
-            <span className="text-[10px] text-white/30 bg-white/5 px-2 py-0.5 rounded-full">
+            <span className="text-[10px] text-white/30 bg-surface-2 px-2 py-0.5 rounded-full">
               {agent.steps_count} etapes
             </span>
-            <span className={cn('text-[10px] px-2 py-0.5 rounded-full bg-white/5', colorClass)}>
+            <span className={cn('text-[10px] px-2 py-0.5 rounded-full bg-surface-2', colorClass)}>
               {CATEGORY_LABELS[agent.category] || agent.category}
             </span>
           </div>
@@ -130,18 +130,18 @@ function ParamsForm({
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center gap-3 p-4 border-b border-white/5">
+      <div className="flex items-center gap-3 p-4 border-b border-border">
         <button
           onClick={onBack}
-          className="p-1 rounded hover:bg-white/5 text-white/40 hover:text-white/70"
+          className="p-1 rounded hover:bg-surface-2 text-white/40 hover:text-white/70"
         >
           <ChevronRight size={16} className="rotate-180" />
         </button>
-        <div className={cn('p-2 rounded-lg bg-white/5', colorClass)}>
+        <div className={cn('p-2 rounded-lg bg-surface-2', colorClass)}>
           <IconComp size={18} />
         </div>
         <div>
-          <h3 className="text-sm font-medium text-white/90">{agent.name}</h3>
+          <h3 className="text-sm font-medium text-text">{agent.name}</h3>
           <p className="text-xs text-white/40">{agent.steps_count} etapes</p>
         </div>
       </div>
@@ -152,7 +152,7 @@ function ParamsForm({
 
         {agent.params.map((param) => (
           <div key={param.id} className="space-y-1.5">
-            <label className="text-xs font-medium text-white/60">
+            <label className="text-xs font-medium text-text-muted">
               {param.label}
               {param.required && <span className="text-red-400 ml-1">*</span>}
             </label>
@@ -164,7 +164,7 @@ function ParamsForm({
                 }
                 className={cn(
                   'w-full px-3 py-2 rounded-lg text-sm',
-                  'bg-[#0B1226] border border-white/10 text-white/80',
+                  'bg-bg border border-border text-text',
                   'focus:border-[#2451FF] focus:outline-none',
                 )}
               >
@@ -185,7 +185,7 @@ function ParamsForm({
                 placeholder={param.placeholder}
                 className={cn(
                   'w-full px-3 py-2 rounded-lg text-sm',
-                  'bg-[#0B1226] border border-white/10 text-white/80',
+                  'bg-bg border border-border text-text',
                   'placeholder:text-white/20',
                   'focus:border-[#2451FF] focus:outline-none',
                 )}
@@ -255,7 +255,7 @@ function TaskProgress({
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-white/5">
+      <div className="flex items-center justify-between p-4 border-b border-border">
         <div>
           <h3 className="text-sm font-medium text-white/90">{task.agent_name}</h3>
           <span className={cn('text-xs', statusColor)}>{statusLabel}</span>
@@ -275,7 +275,7 @@ function TaskProgress({
         ) : (
           <button
             onClick={onClose}
-            className="p-1 rounded hover:bg-white/5 text-white/40"
+            className="p-1 rounded hover:bg-surface-2 text-white/40"
           >
             <X size={16} />
           </button>
@@ -284,7 +284,7 @@ function TaskProgress({
 
       {/* Barre de progression */}
       <div className="px-4 py-3">
-        <div className="h-1.5 bg-white/5 rounded-full overflow-hidden">
+        <div className="h-1.5 bg-surface-2 rounded-full overflow-hidden">
           <motion.div
             className={cn(
               'h-full rounded-full',
@@ -309,7 +309,7 @@ function TaskProgress({
 
       {/* Resultat final */}
       {isDone && task.result && (
-        <div className="border-t border-white/5 p-4">
+        <div className="border-t border-border p-4">
           <p className="text-xs text-white/50 mb-2">Resultat insere dans le chat.</p>
         </div>
       )}
@@ -347,7 +347,7 @@ function StepItem({ step, index: _index }: { step: TaskStep; index: number }) {
           ? 'border-emerald-400/10 bg-emerald-400/5'
           : step.status === 'error'
           ? 'border-red-400/10 bg-red-400/5'
-          : 'border-white/5 bg-transparent',
+          : 'border-border bg-transparent',
       )}
     >
       <button
@@ -355,7 +355,7 @@ function StepItem({ step, index: _index }: { step: TaskStep; index: number }) {
         className="w-full flex items-center gap-2 p-3 text-left"
       >
         {statusIcon}
-        <span className="text-xs text-white/70 flex-1">{step.label}</span>
+        <span className="text-xs text-text-muted flex-1">{step.label}</span>
         <ChevronRight
           size={12}
           className={cn(
@@ -378,7 +378,7 @@ function StepItem({ step, index: _index }: { step: TaskStep; index: number }) {
                 className={cn(
                   'text-xs text-white/50 whitespace-pre-wrap',
                   'max-h-40 overflow-y-auto',
-                  'bg-[#0B1226]/50 rounded-lg p-2',
+                  'bg-bg/50 rounded-lg p-2',
                 )}
               >
                 {step.content}
@@ -469,7 +469,7 @@ export function ActionPanel() {
       return (
         <button
           onClick={() => openPanel()}
-          className="fixed bottom-4 right-4 z-50 flex items-center gap-2 px-4 py-2 rounded-full bg-[#131B35] border border-cyan-400/30 text-sm text-cyan-400 shadow-lg shadow-cyan-400/10 hover:bg-[#1A2340] transition-colors animate-pulse"
+          className="fixed bottom-4 right-4 z-50 flex items-center gap-2 px-4 py-2 rounded-full bg-surface border border-cyan-400/30 text-sm text-cyan-400 shadow-lg shadow-cyan-400/10 hover:bg-surface-elevated transition-colors animate-pulse"
         >
           <Loader2 size={14} className="animate-spin" />
           {activeTask.agent_name || 'Action'} en cours...
@@ -501,20 +501,20 @@ export function ActionPanel() {
         className={cn(
           'fixed right-0 top-0 bottom-0 z-50',
           'w-[380px] max-w-[90vw]',
-          'bg-[#0B1226] border-l border-white/5',
+          'bg-bg border-l border-border',
           'flex flex-col shadow-2xl',
         )}
       >
         {/* Header global */}
         {showList && (
-          <div className="flex items-center justify-between px-4 py-3 border-b border-white/5">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
             <div className="flex items-center gap-2">
               <Zap size={16} className="text-[#22D3EE]" />
-              <h2 className="text-sm font-medium text-white/80">Actions</h2>
+              <h2 className="text-sm font-medium text-text">Actions</h2>
             </div>
             <button
               onClick={closePanel}
-              className="p-1 rounded hover:bg-white/5 text-white/40 hover:text-white/70"
+              className="p-1 rounded hover:bg-surface-2 text-white/40 hover:text-white/70"
             >
               <X size={16} />
             </button>

--- a/src/frontend/src/components/actions/ActionPanel.tsx
+++ b/src/frontend/src/components/actions/ActionPanel.tsx
@@ -79,14 +79,14 @@ function AgentCard({
             </h3>
             <ChevronRight
               size={16}
-              className="text-white/20 group-hover:text-white/50 transition-colors flex-shrink-0"
+              className="text-text-muted group-hover:text-text transition-colors flex-shrink-0"
             />
           </div>
-          <p className="text-xs text-white/40 mt-1 line-clamp-2">
+          <p className="text-xs text-text-muted mt-1 line-clamp-2">
             {agent.description}
           </p>
           <div className="flex items-center gap-2 mt-2">
-            <span className="text-[10px] text-white/30 bg-surface-2 px-2 py-0.5 rounded-full">
+            <span className="text-[10px] text-text-muted bg-surface-2 px-2 py-0.5 rounded-full">
               {agent.steps_count} etapes
             </span>
             <span className={cn('text-[10px] px-2 py-0.5 rounded-full bg-surface-2', colorClass)}>
@@ -133,7 +133,7 @@ function ParamsForm({
       <div className="flex items-center gap-3 p-4 border-b border-border">
         <button
           onClick={onBack}
-          className="p-1 rounded hover:bg-surface-2 text-white/40 hover:text-white/70"
+          className="p-1 rounded hover:bg-surface-2 text-text-muted hover:text-text"
         >
           <ChevronRight size={16} className="rotate-180" />
         </button>
@@ -142,13 +142,13 @@ function ParamsForm({
         </div>
         <div>
           <h3 className="text-sm font-medium text-text">{agent.name}</h3>
-          <p className="text-xs text-white/40">{agent.steps_count} etapes</p>
+          <p className="text-xs text-text-muted">{agent.steps_count} etapes</p>
         </div>
       </div>
 
       {/* Form */}
       <form onSubmit={handleSubmit} className="flex-1 flex flex-col p-4 gap-4">
-        <p className="text-xs text-white/50">{agent.description}</p>
+        <p className="text-xs text-text-muted">{agent.description}</p>
 
         {agent.params.map((param) => (
           <div key={param.id} className="space-y-1.5">
@@ -186,7 +186,7 @@ function ParamsForm({
                 className={cn(
                   'w-full px-3 py-2 rounded-lg text-sm',
                   'bg-bg border border-border text-text',
-                  'placeholder:text-white/20',
+                  'placeholder:text-text-muted',
                   'focus:border-[#2451FF] focus:outline-none',
                 )}
               />
@@ -248,7 +248,7 @@ function TaskProgress({
     pending: 'text-yellow-400',
     running: 'text-cyan-400',
     completed: 'text-emerald-400',
-    cancelled: 'text-white/40',
+    cancelled: 'text-text-muted',
     error: 'text-red-400',
   }[task.status];
 
@@ -257,7 +257,7 @@ function TaskProgress({
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-border">
         <div>
-          <h3 className="text-sm font-medium text-white/90">{task.agent_name}</h3>
+          <h3 className="text-sm font-medium text-text">{task.agent_name}</h3>
           <span className={cn('text-xs', statusColor)}>{statusLabel}</span>
         </div>
         {isRunning ? (
@@ -275,7 +275,7 @@ function TaskProgress({
         ) : (
           <button
             onClick={onClose}
-            className="p-1 rounded hover:bg-surface-2 text-white/40"
+            className="p-1 rounded hover:bg-surface-2 text-text-muted"
           >
             <X size={16} />
           </button>
@@ -295,7 +295,7 @@ function TaskProgress({
             transition={{ duration: 0.3 }}
           />
         </div>
-        <p className="text-[10px] text-white/30 mt-1 text-right">
+        <p className="text-[10px] text-text-muted mt-1 text-right">
           {Math.round(task.progress * 100)}%
         </p>
       </div>
@@ -310,7 +310,7 @@ function TaskProgress({
       {/* Resultat final */}
       {isDone && task.result && (
         <div className="border-t border-border p-4">
-          <p className="text-xs text-white/50 mb-2">Resultat insere dans le chat.</p>
+          <p className="text-xs text-text-muted mb-2">Resultat insere dans le chat.</p>
         </div>
       )}
     </div>
@@ -323,10 +323,10 @@ function StepItem({ step, index: _index }: { step: TaskStep; index: number }) {
   );
 
   const statusIcon = {
-    pending: <Clock size={14} className="text-white/20" />,
+    pending: <Clock size={14} className="text-text-muted" />,
     running: <Loader2 size={14} className="text-cyan-400 animate-spin" />,
     completed: <CheckCircle2 size={14} className="text-emerald-400" />,
-    skipped: <Clock size={14} className="text-white/20" />,
+    skipped: <Clock size={14} className="text-text-muted" />,
     error: <AlertCircle size={14} className="text-red-400" />,
   }[step.status];
 
@@ -359,7 +359,7 @@ function StepItem({ step, index: _index }: { step: TaskStep; index: number }) {
         <ChevronRight
           size={12}
           className={cn(
-            'text-white/20 transition-transform',
+            'text-text-muted transition-transform',
             expanded && 'rotate-90',
           )}
         />
@@ -376,7 +376,7 @@ function StepItem({ step, index: _index }: { step: TaskStep; index: number }) {
             <div className="px-3 pb-3 pt-0">
               <div
                 className={cn(
-                  'text-xs text-white/50 whitespace-pre-wrap',
+                  'text-xs text-text-muted whitespace-pre-wrap',
                   'max-h-40 overflow-y-auto',
                   'bg-bg/50 rounded-lg p-2',
                 )}
@@ -514,7 +514,7 @@ export function ActionPanel() {
             </div>
             <button
               onClick={closePanel}
-              className="p-1 rounded hover:bg-surface-2 text-white/40 hover:text-white/70"
+              className="p-1 rounded hover:bg-surface-2 text-text-muted hover:text-text"
             >
               <X size={16} />
             </button>
@@ -527,7 +527,7 @@ export function ActionPanel() {
             <div className="h-full overflow-y-auto p-4 space-y-6">
               {Object.entries(grouped).map(([category, catAgents]) => (
                 <div key={category}>
-                  <h3 className={cn('text-xs font-semibold uppercase tracking-wider mb-3', CATEGORY_COLORS[category] || 'text-white/40')}>
+                  <h3 className={cn('text-xs font-semibold uppercase tracking-wider mb-3', CATEGORY_COLORS[category] || 'text-text-muted')}>
                     {CATEGORY_LABELS[category] || category}
                   </h3>
                   <div className="space-y-2">
@@ -543,14 +543,14 @@ export function ActionPanel() {
               ))}
 
               {agents.length === 0 && !isLoading && (
-                <p className="text-sm text-white/30 text-center py-8">
+                <p className="text-sm text-text-muted text-center py-8">
                   Aucune action disponible.
                 </p>
               )}
 
               {isLoading && (
                 <div className="flex justify-center py-8">
-                  <Loader2 size={24} className="text-white/20 animate-spin" />
+                  <Loader2 size={24} className="text-text-muted animate-spin" />
                 </div>
               )}
             </div>

--- a/src/frontend/src/components/atelier/AgentCatalog.tsx
+++ b/src/frontend/src/components/atelier/AgentCatalog.tsx
@@ -51,9 +51,9 @@ const COLOR_MAP: Record<string, { border: string; bg: string; text: string }> = 
 };
 
 const DEFAULT_COLOR = {
-  border: "border-white/10",
-  bg: "bg-white/5",
-  text: "text-[#B6C7DA]",
+  border: "border-border",
+  bg: "bg-surface-2",
+  text: "text-text-muted",
 };
 
 /** Profils par defaut si le backend ne repond pas */
@@ -181,8 +181,8 @@ export function AgentCatalog({ onSelectAgent }: Props) {
   if (loading) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3">
-        <Loader2 size={24} className="animate-spin text-[#6B7280]" />
-        <p className="text-xs text-[#6B7280]">Chargement des agents...</p>
+        <Loader2 size={24} className="animate-spin text-text-muted" />
+        <p className="text-xs text-text-muted">Chargement des agents...</p>
       </div>
     );
   }
@@ -203,10 +203,10 @@ export function AgentCatalog({ onSelectAgent }: Props) {
         <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-cyan-500/10">
           <Bot size={20} className="text-cyan-400" />
         </div>
-        <h3 className="mb-1 text-sm font-semibold text-[#E6EDF7]">
+        <h3 className="mb-1 text-sm font-semibold text-text">
           Choisis un agent
         </h3>
-        <p className="text-xs text-[#6B7280]">
+        <p className="text-xs text-text-muted">
           Chaque agent est specialise dans un domaine. Selectionne celui qui correspond a ta tache.
         </p>
       </div>
@@ -214,7 +214,7 @@ export function AgentCatalog({ onSelectAgent }: Props) {
       {/* Selecteur de modele LLM */}
       {availableModels.length > 0 && (
         <div className="mb-4 space-y-2">
-          <div className="flex items-center gap-2 rounded-lg border border-white/5 bg-[#131B35] px-3 py-2">
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-2">
             <Brain size={14} className="shrink-0 text-cyan-400" />
             <select
               value={selectedModel}
@@ -225,7 +225,7 @@ export function AgentCatalog({ onSelectAgent }: Props) {
                 setCustomModel("");
                 localStorage.removeItem(CUSTOM_MODEL_STORAGE_KEY);
               }}
-              className="flex-1 bg-transparent text-xs text-[#E6EDF7] outline-none [&>optgroup]:bg-[#131B35] [&>option]:bg-[#131B35]"
+              className="flex-1 bg-transparent text-xs text-text outline-none [&>optgroup]:bg-[#131B35] [&>option]:bg-[#131B35]"
             >
               {Object.entries(
                 availableModels.reduce<Record<string, AgentModelInfo[]>>((acc, m) => {
@@ -245,7 +245,7 @@ export function AgentCatalog({ onSelectAgent }: Props) {
           </div>
 
           {/* Champ libre pour modele OpenRouter personnalise (SUG-030) */}
-          <div className="flex items-center gap-2 rounded-lg border border-white/5 bg-[#131B35] px-3 py-2">
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-2">
             <span className="shrink-0 text-[10px] text-cyan-400/70">OR</span>
             <input
               type="text"
@@ -260,7 +260,7 @@ export function AgentCatalog({ onSelectAgent }: Props) {
                 }
               }}
               placeholder="ex: meta-llama/llama-4-maverick:free"
-              className="flex-1 bg-transparent text-xs text-[#E6EDF7] placeholder-[#6B7280]/50 outline-none"
+              className="flex-1 bg-transparent text-xs text-text placeholder-[#6B7280]/50 outline-none"
             />
             {customModel.trim() && (
               <button
@@ -269,7 +269,7 @@ export function AgentCatalog({ onSelectAgent }: Props) {
                   setCustomModel("");
                   localStorage.removeItem(CUSTOM_MODEL_STORAGE_KEY);
                 }}
-                className="shrink-0 text-[10px] text-[#6B7280] hover:text-red-400 transition-colors"
+                className="shrink-0 text-[10px] text-text-muted hover:text-red-400 transition-colors"
               >
                 ✕
               </button>
@@ -295,7 +295,7 @@ export function AgentCatalog({ onSelectAgent }: Props) {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.25, delay: index * 0.06 }}
               onClick={() => onSelectAgent(profile.id, customModel.trim() || selectedModel || undefined)}
-              className={`group flex flex-col items-center gap-2 rounded-xl border ${colors.border} bg-[#131B35] p-4 text-center transition-all hover:border-cyan-400/50 hover:bg-[#1a2340]`}
+              className={`group flex flex-col items-center gap-2 rounded-xl border ${colors.border} bg-surface p-4 text-center transition-all hover:border-cyan-400/50 hover:bg-surface-elevated`}
             >
               {/* Icone */}
               <div
@@ -315,12 +315,12 @@ export function AgentCatalog({ onSelectAgent }: Props) {
               </span>
 
               {/* Description */}
-              <span className="text-[10px] leading-snug text-[#6B7280]">
+              <span className="text-[10px] leading-snug text-text-muted">
                 {profile.description}
               </span>
 
               {/* Nombre d'outils */}
-              <span className="mt-auto text-[9px] text-[#6B7280]/60">
+              <span className="mt-auto text-[9px] text-text-muted/60">
                 {profile.tools.length} outil{profile.tools.length > 1 ? "s" : ""}
               </span>
             </motion.button>

--- a/src/frontend/src/components/atelier/AgentCatalog.tsx
+++ b/src/frontend/src/components/atelier/AgentCatalog.tsx
@@ -79,7 +79,7 @@ const FALLBACK_PROFILES: AgentProfile[] = [
   {
     id: "analyst",
     name: "Analyste",
-    description: "Analyse de donnees, code et documents",
+    description: "Analyse de données, code et documents",
     icon: "\uD83D\uDCCA",
     color: "blue",
     tools: ["read_file", "search_codebase", "run_command"],
@@ -277,7 +277,7 @@ export function AgentCatalog({ onSelectAgent }: Props) {
           </div>
           {customModel.trim() && (
             <p className="text-[10px] text-cyan-400/60 px-1">
-              Modele personnalise actif - prioritaire sur la liste
+              Modèle personnalisé actif - prioritaire sur la liste
             </p>
           )}
         </div>

--- a/src/frontend/src/components/atelier/AgentChat.tsx
+++ b/src/frontend/src/components/atelier/AgentChat.tsx
@@ -393,7 +393,7 @@ export function AgentChat() {
       {activeSession.status !== "running" && (
         <div className="border-t border-border px-3 py-2 text-center">
           <span className="text-xs text-text-muted">
-            Session {activeSession.status === "done" ? "terminee" : activeSession.status === "error" ? "en erreur" : "annulee"}
+            Session {activeSession.status === "done" ? "terminée" : activeSession.status === "error" ? "en erreur" : "annulée"}
             {activeSession.result_summary && (
               <span title={activeSession.result_summary}>
                 {" "}- {activeSession.result_summary.length > 80

--- a/src/frontend/src/components/atelier/AgentChat.tsx
+++ b/src/frontend/src/components/atelier/AgentChat.tsx
@@ -91,7 +91,7 @@ function CopyButton({ text }: { text: string }) {
   return (
     <button
       onClick={handleCopy}
-      className="rounded p-0.5 text-[#6B7280] transition hover:bg-white/5 hover:text-[#B6C7DA]"
+      className="rounded p-0.5 text-text-muted transition hover:bg-surface-2 hover:text-text-muted"
       title="Copier le message"
       aria-label="Copier le message"
     >
@@ -186,7 +186,7 @@ export function AgentChat() {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
         <Headphones size={32} className="text-purple-400/30" />
-        <p className="text-xs text-[#6B7280]">
+        <p className="text-xs text-text-muted">
           Selectionnez une session ou lancez une nouvelle tache.
         </p>
       </div>
@@ -204,14 +204,14 @@ export function AgentChat() {
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       {/* Session header */}
-      <div className="flex items-center justify-between border-b border-white/5 px-3 py-2">
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
         <div className="flex-1 min-w-0">
-          <p className="truncate text-xs font-medium text-[#E6EDF7]">
+          <p className="truncate text-xs font-medium text-text">
             {activeSession.instruction.length > 80
               ? activeSession.instruction.slice(0, 80) + "..."
               : activeSession.instruction}
           </p>
-          <p className="text-[10px] text-[#6B7280]">
+          <p className="text-[10px] text-text-muted">
             Agent : {activeSession.agent_name} - {activeSession.status}
             {activeSession.actions_count > 0 && (
               <> - {activeSession.actions_count} action{activeSession.actions_count > 1 ? "s" : ""}</>
@@ -221,7 +221,7 @@ export function AgentChat() {
         <div className="flex items-center gap-1 ml-2">
           <button
             onClick={refreshActiveSession}
-            className="rounded p-1 text-[#6B7280] transition hover:bg-white/5 hover:text-[#B6C7DA]"
+            className="rounded p-1 text-text-muted transition hover:bg-surface-2 hover:text-text-muted"
             title="Rafraichir"
             aria-label="Rafraichir la session"
           >
@@ -254,10 +254,10 @@ export function AgentChat() {
                 <div className="flex h-10 w-10 items-center justify-center rounded-full bg-purple-500/10">
                   <Headphones size={20} className="animate-pulse text-purple-400" />
                 </div>
-                <p className="text-xs text-[#6B7280]">Katia travaille sur la tache...</p>
+                <p className="text-xs text-text-muted">Katia travaille sur la tache...</p>
               </>
             ) : (
-              <p className="text-xs text-[#6B7280]">Aucun message dans cette session.</p>
+              <p className="text-xs text-text-muted">Aucun message dans cette session.</p>
             )}
           </div>
         ) : (
@@ -328,7 +328,7 @@ export function AgentChat() {
                       </div>
                       {msg.timestamp && (
                         <div className="mt-0.5 flex items-center gap-1.5">
-                          <span className="text-[10px] text-[#6B7280]">
+                          <span className="text-[10px] text-text-muted">
                             {new Date(msg.timestamp).toLocaleTimeString("fr-FR", {
                               hour: "2-digit",
                               minute: "2-digit",
@@ -351,7 +351,7 @@ export function AgentChat() {
 
       {/* Input (only if session is running) */}
       {activeSession.status === "running" && (
-        <div className="flex items-end gap-2 border-t border-white/5 bg-[#0B1226] px-3 py-2.5">
+        <div className="flex items-end gap-2 border-t border-border bg-bg px-3 py-2.5">
           <textarea
             ref={inputRef}
             value={input}
@@ -360,7 +360,7 @@ export function AgentChat() {
             placeholder="Envoyer un message a Katia..."
             disabled={isSending}
             rows={1}
-            className="flex-1 resize-none rounded-lg border border-white/10 bg-[#131B35] px-3 py-2 text-sm text-[#E6EDF7] placeholder-[#6B7280] outline-none transition focus:border-purple-500/50 disabled:opacity-50"
+            className="flex-1 resize-none rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder-[#6B7280] outline-none transition focus:border-purple-500/50 disabled:opacity-50"
             style={{ minHeight: "38px", maxHeight: "120px" }}
             onInput={(e) => {
               const target = e.target as HTMLTextAreaElement;
@@ -370,7 +370,7 @@ export function AgentChat() {
           />
           {isSending ? (
             <button
-              className="flex h-9 w-9 items-center justify-center rounded-lg bg-gray-500/20 text-gray-400"
+              className="flex h-9 w-9 items-center justify-center rounded-lg bg-surface-2 text-text-muted"
               disabled
             >
               <Square size={16} className="animate-pulse" />
@@ -391,8 +391,8 @@ export function AgentChat() {
 
       {/* Session terminee */}
       {activeSession.status !== "running" && (
-        <div className="border-t border-white/5 px-3 py-2 text-center">
-          <span className="text-xs text-[#6B7280]">
+        <div className="border-t border-border px-3 py-2 text-center">
+          <span className="text-xs text-text-muted">
             Session {activeSession.status === "done" ? "terminee" : activeSession.status === "error" ? "en erreur" : "annulee"}
             {activeSession.result_summary && (
               <span title={activeSession.result_summary}>

--- a/src/frontend/src/components/atelier/AgentInput.tsx
+++ b/src/frontend/src/components/atelier/AgentInput.tsx
@@ -34,7 +34,7 @@ export function AgentInput({ onSend, onCancel, isStreaming, placeholder }: Props
   };
 
   return (
-    <div className="flex items-end gap-2 border-t border-white/5 bg-[#0B1226] px-3 py-2.5">
+    <div className="flex items-end gap-2 border-t border-border bg-bg px-3 py-2.5">
       <textarea
         ref={inputRef}
         value={value}
@@ -43,7 +43,7 @@ export function AgentInput({ onSend, onCancel, isStreaming, placeholder }: Props
         placeholder={placeholder || 'Décris ce que tu veux...'}
         disabled={isStreaming}
         rows={1}
-        className="flex-1 resize-none rounded-lg border border-white/10 bg-[#131B35] px-3 py-2 text-sm text-[#E6EDF7] placeholder-[#6B7280] outline-none transition focus:border-purple-500/50 disabled:opacity-50"
+        className="flex-1 resize-none rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder-[#6B7280] outline-none transition focus:border-purple-500/50 disabled:opacity-50"
         style={{ minHeight: '38px', maxHeight: '120px' }}
         onInput={(e) => {
           const target = e.target as HTMLTextAreaElement;

--- a/src/frontend/src/components/atelier/AgentMessageBubble.tsx
+++ b/src/frontend/src/components/atelier/AgentMessageBubble.tsx
@@ -48,7 +48,7 @@ export function AgentMessageBubble({ message }: Props) {
   // Messages système compacts (tool_use, test_result)
   if (isSystem && (message.type === 'tool_use' || message.type === 'test_result')) {
     return (
-      <div className="flex items-center gap-2 px-3 py-1.5 text-xs text-[#B6C7DA] opacity-70">
+      <div className="flex items-center gap-2 px-3 py-1.5 text-xs text-text-muted opacity-70">
         <span style={{ color: style.color }}>{style.icon}</span>
         <span>{message.content}</span>
       </div>
@@ -66,12 +66,12 @@ export function AgentMessageBubble({ message }: Props) {
           borderImage: 'linear-gradient(to bottom, #A855F7, #F59E0B) 1',
         }}
       >
-        <div className="mb-1 flex items-center gap-2 text-xs font-medium text-[#B6C7DA]">
+        <div className="mb-1 flex items-center gap-2 text-xs font-medium text-text-muted">
           <Headphones size={12} className="text-purple-400" />
           <span>Katia transmet à Zézette</span>
           <Wrench size={12} className="text-amber-400" />
         </div>
-        <div className="text-[#E6EDF7]">{message.content}</div>
+        <div className="text-text">{message.content}</div>
       </div>
     );
   }

--- a/src/frontend/src/components/atelier/AgentSession.tsx
+++ b/src/frontend/src/components/atelier/AgentSession.tsx
@@ -46,7 +46,7 @@ const COLOR_MAP: Record<string, { accent: string; bg: string }> = {
   amber: { accent: "text-amber-400", bg: "bg-amber-500/10" },
 };
 
-const DEFAULT_COLOR = { accent: "text-[#B6C7DA]", bg: "bg-white/5" };
+const DEFAULT_COLOR = { accent: "text-text-muted", bg: "bg-surface-2" };
 
 /** Profils par defaut (identiques a AgentCatalog) */
 const PROFILE_MAP: Record<string, AgentProfile> = {
@@ -141,18 +141,18 @@ function ToolCallBlock({
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="mx-3 my-1.5 rounded-lg border border-white/5 bg-[#0e1529]">
+    <div className="mx-3 my-1.5 rounded-lg border border-border bg-surface-2">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-[#B6C7DA] transition hover:bg-white/5"
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-muted transition hover:bg-surface-elevated"
       >
         <Wrench size={12} className="flex-shrink-0 text-amber-400/70" />
         <span className="flex-1 truncate font-medium">{toolName}</span>
         {toolResult && (
           expanded ? (
-            <ChevronDown size={12} className="flex-shrink-0 text-[#6B7280]" />
+            <ChevronDown size={12} className="flex-shrink-0 text-text-muted" />
           ) : (
-            <ChevronRight size={12} className="flex-shrink-0 text-[#6B7280]" />
+            <ChevronRight size={12} className="flex-shrink-0 text-text-muted" />
           )
         )}
       </button>
@@ -165,7 +165,7 @@ function ToolCallBlock({
             transition={{ duration: 0.15 }}
             className="overflow-hidden"
           >
-            <pre className="border-t border-white/5 px-3 py-2 text-[10px] leading-relaxed text-[#6B7280] overflow-x-auto max-h-40 overflow-y-auto">
+            <pre className="border-t border-border px-3 py-2 text-[10px] leading-relaxed text-text-muted overflow-x-auto max-h-40 overflow-y-auto">
               {toolResult}
             </pre>
           </motion.div>
@@ -381,10 +381,10 @@ export function AgentSession({ profileId, model, onBack }: Props) {
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       {/* Header */}
-      <div className="flex items-center gap-2 border-b border-white/5 px-3 py-2.5">
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
         <button
           onClick={onBack}
-          className="flex h-7 w-7 items-center justify-center rounded-lg text-[#6B7280] transition hover:bg-white/5 hover:text-[#E6EDF7]"
+          className="flex h-7 w-7 items-center justify-center rounded-lg text-text-muted transition hover:bg-surface-2 hover:text-text"
           title="Retour au catalogue"
         >
           <ArrowLeft size={16} />
@@ -404,7 +404,7 @@ export function AgentSession({ profileId, model, onBack }: Props) {
 
         {/* Badge modele */}
         {activeModel && (
-          <span className="ml-auto rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-[#6B7280]">
+          <span className="ml-auto rounded bg-surface-2 px-1.5 py-0.5 text-[10px] text-text-muted">
             {activeModel}
           </span>
         )}
@@ -522,7 +522,7 @@ export function AgentSession({ profileId, model, onBack }: Props) {
       </div>
 
       {/* Input */}
-      <div className="flex items-end gap-2 border-t border-white/5 bg-[#0B1226] px-3 py-2.5">
+      <div className="flex items-end gap-2 border-t border-border bg-bg px-3 py-2.5">
         <textarea
           ref={inputRef}
           value={inputValue}
@@ -535,7 +535,7 @@ export function AgentSession({ profileId, model, onBack }: Props) {
           }
           disabled={isStreaming}
           rows={1}
-          className="flex-1 resize-none rounded-lg border border-white/10 bg-[#131B35] px-3 py-2 text-sm text-[#E6EDF7] placeholder-[#6B7280] outline-none transition focus:border-cyan-500/50 disabled:opacity-50"
+          className="flex-1 resize-none rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder-[#6B7280] outline-none transition focus:border-cyan-500/50 disabled:opacity-50"
           style={{ minHeight: "38px", maxHeight: "120px" }}
           onInput={(e) => {
             const target = e.target as HTMLTextAreaElement;
@@ -596,7 +596,7 @@ function InitialPrompt({
         <h3 className={`mb-1 text-sm font-semibold ${colors.accent}`}>
           {profile.name}
         </h3>
-        <p className="text-xs leading-relaxed text-[#6B7280]">
+        <p className="text-xs leading-relaxed text-text-muted">
           {profile.description}
         </p>
       </div>
@@ -604,7 +604,7 @@ function InitialPrompt({
         {profile.tools.map((tool) => (
           <span
             key={tool}
-            className="rounded bg-white/5 px-2 py-0.5 text-[10px] text-[#6B7280]"
+            className="rounded bg-surface-2 px-2 py-0.5 text-[10px] text-text-muted"
           >
             {tool}
           </span>

--- a/src/frontend/src/components/atelier/AgentSession.tsx
+++ b/src/frontend/src/components/atelier/AgentSession.tsx
@@ -71,7 +71,7 @@ const PROFILE_MAP: Record<string, AgentProfile> = {
   analyst: {
     id: "analyst",
     name: "Analyste",
-    description: "Analyse de donnees, code et documents",
+    description: "Analyse de données, code et documents",
     icon: "\uD83D\uDCCA",
     color: "blue",
     tools: ["read_file", "search_codebase", "run_command"],

--- a/src/frontend/src/components/atelier/AtelierPanel.tsx
+++ b/src/frontend/src/components/atelier/AtelierPanel.tsx
@@ -107,17 +107,17 @@ export function AtelierPanel() {
 
   return (
     <div
-      className={`fixed right-0 top-0 ${Z_LAYER.MODAL} flex h-full flex-col border-l border-white/5 bg-[#0B1226] shadow-2xl`}
+      className={`fixed right-0 top-0 ${Z_LAYER.MODAL} flex h-full flex-col border-l border-border bg-bg shadow-2xl`}
       style={{ width: "480px" }}
     >
       {/* Header */}
-      <div className="flex flex-col border-b border-white/5">
+      <div className="flex flex-col border-b border-border">
         <div className="flex items-center justify-between px-4 py-3">
           <div className="flex items-center gap-2">
             <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-purple-500/20">
               <Zap size={14} className="text-purple-400" />
             </div>
-            <span className="text-sm font-semibold text-[#E6EDF7]">Atelier</span>
+            <span className="text-sm font-semibold text-text">Atelier</span>
           </div>
 
           {/* Navigation */}
@@ -158,7 +158,7 @@ export function AtelierPanel() {
 
           <button
             onClick={closePanel}
-            className="flex h-7 w-7 items-center justify-center rounded-lg text-[#6B7280] transition hover:bg-white/5 hover:text-[#E6EDF7]"
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-text-muted transition hover:bg-surface-2 hover:text-text"
           >
             <X size={16} />
           </button>
@@ -166,7 +166,7 @@ export function AtelierPanel() {
 
         {/* BUG-111 : Badges modèles Katia & Zézette (masqués en vue Agents) */}
         {showModelBadge && activeView !== "agents" && (
-          <div className="flex items-center gap-2 px-4 pb-2 text-[10px] text-[#6B7280]">
+          <div className="flex items-center gap-2 px-4 pb-2 text-[10px] text-text-muted">
             {katiaModel && (
               <span className="rounded bg-purple-500/10 px-1.5 py-0.5 text-purple-400">
                 Katia: {katiaModel}
@@ -215,7 +215,7 @@ export function AtelierPanel() {
         {activeView === "mission" && (
           <div ref={scrollRef} className="flex-1 overflow-y-auto py-2">
             {messages.length === 0 ? (
-              <div className="flex h-full items-center justify-center text-sm text-[#6B7280]">
+              <div className="flex h-full items-center justify-center text-sm text-text-muted">
                 Aucune mission en cours
               </div>
             ) : (
@@ -269,7 +269,7 @@ function NavButton({
       className={`relative flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition ${
         active
           ? "bg-purple-500/20 text-purple-400"
-          : "text-[#6B7280] hover:bg-white/5 hover:text-[#B6C7DA]"
+          : "text-text-muted hover:bg-surface-2 hover:text-text-muted"
       }`}
     >
       {icon}
@@ -293,10 +293,10 @@ function EmptyState() {
         </div>
       </div>
       <div>
-        <h3 className="mb-1 text-sm font-semibold text-[#E6EDF7]">
+        <h3 className="mb-1 text-sm font-semibold text-text">
           Bienvenue dans l&apos;Atelier
         </h3>
-        <p className="text-xs leading-relaxed text-[#6B7280]">
+        <p className="text-xs leading-relaxed text-text-muted">
           Katia te guide et comprend tes besoins. Zézette implémente les
           changements. Posez une question ou demandez une amélioration.
         </p>

--- a/src/frontend/src/components/atelier/CodeReviewPanel.tsx
+++ b/src/frontend/src/components/atelier/CodeReviewPanel.tsx
@@ -65,7 +65,7 @@ export function CodeReviewPanel() {
 
   if (!currentMission) {
     return (
-      <div className="flex h-full items-center justify-center text-sm text-[#6B7280]">
+      <div className="flex h-full items-center justify-center text-sm text-text-muted">
         Aucune mission en cours
       </div>
     );
@@ -75,19 +75,19 @@ export function CodeReviewPanel() {
     <div className="flex h-full flex-col">
       {/* Explication par Katia */}
       {currentMission.explanation && (
-        <div className="border-b border-white/5 px-4 py-3">
+        <div className="border-b border-border px-4 py-3">
           <div className="mb-1 text-xs font-medium text-purple-400">
             Explication de Katia
           </div>
-          <div className="text-sm leading-relaxed text-[#E6EDF7]">
+          <div className="text-sm leading-relaxed text-text">
             {currentMission.explanation}
           </div>
         </div>
       )}
 
       {/* Résumé des changements */}
-      <div className="border-b border-white/5 px-4 py-2">
-        <div className="flex items-center gap-3 text-xs text-[#B6C7DA]">
+      <div className="border-b border-border px-4 py-2">
+        <div className="flex items-center gap-3 text-xs text-text-muted">
           <span className="flex items-center gap-1 text-green-400">
             <Plus size={12} /> {totalAdd} ajouts
           </span>
@@ -101,25 +101,25 @@ export function CodeReviewPanel() {
       {/* Liste des fichiers */}
       <div className="flex-1 overflow-y-auto">
         {isLoading ? (
-          <div className="flex items-center justify-center py-8 text-sm text-[#6B7280]">
+          <div className="flex items-center justify-center py-8 text-sm text-text-muted">
             Chargement des modifications...
           </div>
         ) : (
           diffFiles.map((file) => (
-            <div key={file.file_path} className="border-b border-white/5">
+            <div key={file.file_path} className="border-b border-border">
               <button
                 onClick={() => setExpandedFile(
                   expandedFile === file.file_path ? null : file.file_path
                 )}
-                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm transition hover:bg-white/5"
+                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm transition hover:bg-surface-2"
               >
                 {expandedFile === file.file_path ? (
-                  <ChevronDown size={14} className="text-[#6B7280]" />
+                  <ChevronDown size={14} className="text-text-muted" />
                 ) : (
-                  <ChevronRight size={14} className="text-[#6B7280]" />
+                  <ChevronRight size={14} className="text-text-muted" />
                 )}
-                <FileText size={14} className="text-[#B6C7DA]" />
-                <span className="flex-1 truncate text-[#E6EDF7]">
+                <FileText size={14} className="text-text-muted" />
+                <span className="flex-1 truncate text-text">
                   {file.file_path}
                 </span>
                 <span className={`text-xs ${
@@ -167,11 +167,11 @@ export function CodeReviewPanel() {
 
       {/* Actions */}
       {actionDone ? (
-        <div className="border-t border-white/5 px-4 py-3 text-center text-sm text-[#B6C7DA]">
+        <div className="border-t border-border px-4 py-3 text-center text-sm text-text-muted">
           {actionDone}
         </div>
       ) : (
-        <div className="flex gap-3 border-t border-white/5 px-4 py-3">
+        <div className="flex gap-3 border-t border-border px-4 py-3">
           <button
             onClick={handleApprove}
             disabled={actionPending !== null}

--- a/src/frontend/src/components/atelier/NewTaskDialog.tsx
+++ b/src/frontend/src/components/atelier/NewTaskDialog.tsx
@@ -45,22 +45,22 @@ export function NewTaskDialog() {
   return (
     <div className={`fixed inset-0 ${Z_LAYER.MODAL_NESTED} flex items-center justify-center bg-black/50 backdrop-blur-sm`}>
       <div
-        className="mx-4 w-full max-w-lg rounded-xl border border-white/10 bg-[#0F172A] shadow-2xl"
+        className="mx-4 w-full max-w-lg rounded-xl border border-border bg-bg shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-white/5 px-5 py-3">
+        <div className="flex items-center justify-between border-b border-border px-5 py-3">
           <div className="flex items-center gap-2">
             <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-purple-500/20">
               <Zap size={14} className="text-purple-400" />
             </div>
-            <span className="text-sm font-semibold text-[#E6EDF7]">
+            <span className="text-sm font-semibold text-text">
               Nouvelle tâche pour Katia
             </span>
           </div>
           <button
             onClick={closeNewTask}
-            className="rounded-lg p-1.5 text-[#6B7280] transition hover:bg-white/5 hover:text-[#E6EDF7]"
+            className="rounded-lg p-1.5 text-text-muted transition hover:bg-surface-2 hover:text-text"
           >
             <X size={16} />
           </button>
@@ -74,7 +74,7 @@ export function NewTaskDialog() {
             </div>
           )}
 
-          <label className="mb-2 block text-xs font-medium text-[#B6C7DA]">
+          <label className="mb-2 block text-xs font-medium text-text-muted">
             Que veux-tu que Katia fasse ?
           </label>
           <textarea
@@ -84,12 +84,12 @@ export function NewTaskDialog() {
             onKeyDown={handleKeyDown}
             placeholder="Ex: Envoie un email de relance à Jean Dupont pour la facture F-2024-042..."
             rows={4}
-            className="w-full resize-none rounded-lg border border-white/10 bg-[#131B35] px-3 py-2.5 text-sm text-[#E6EDF7] placeholder-[#6B7280] outline-none transition focus:border-purple-500/50"
+            className="w-full resize-none rounded-lg border border-border bg-surface px-3 py-2.5 text-sm text-text placeholder-[#6B7280] outline-none transition focus:border-purple-500/50"
             disabled={isDispatching}
           />
-          <p className="mt-1.5 text-xs text-[#6B7280]">
+          <p className="mt-1.5 text-xs text-text-muted">
             Katia peut envoyer des emails, créer des factures, gérer le CRM et plus encore.
-            <span className="ml-1 text-[#B6C7DA]">Cmd+Entrée</span> pour lancer.
+            <span className="ml-1 text-text-muted">Cmd+Entrée</span> pour lancer.
           </p>
 
           {isMaxReached && (
@@ -100,10 +100,10 @@ export function NewTaskDialog() {
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-2 border-t border-white/5 px-5 py-3">
+        <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-3">
           <button
             onClick={closeNewTask}
-            className="rounded-lg px-3 py-1.5 text-xs font-medium text-[#B6C7DA] transition hover:bg-white/5"
+            className="rounded-lg px-3 py-1.5 text-xs font-medium text-text-muted transition hover:bg-surface-2"
             disabled={isDispatching}
           >
             Annuler

--- a/src/frontend/src/components/atelier/SessionList.tsx
+++ b/src/frontend/src/components/atelier/SessionList.tsx
@@ -14,7 +14,7 @@ import { useAccessibilityStore } from "../../stores/accessibilityStore";
 
 const STATUS_COLORS: Record<string, { dot: string; text: string; label: string }> = {
   running: { dot: "bg-green-400", text: "text-green-400", label: "En cours" },
-  done: { dot: "bg-gray-400", text: "text-gray-400", label: "Terminée" },
+  done: { dot: "bg-text-muted", text: "text-text-muted", label: "Terminée" },
   error: { dot: "bg-red-400", text: "text-red-400", label: "Erreur" },
   cancelled: { dot: "bg-amber-400", text: "text-amber-400", label: "Annulée" },
 };
@@ -34,7 +34,7 @@ function formatDuration(startStr: string, endStr?: string): string {
 /** Barre de progression animée pour sessions running */
 function RunningProgressBar() {
   return (
-    <div className="mt-1.5 ml-4 h-1 w-full overflow-hidden rounded-full bg-white/5">
+    <div className="mt-1.5 ml-4 h-1 w-full overflow-hidden rounded-full bg-surface-2">
       <motion.div
         className="h-full rounded-full bg-gradient-to-r from-purple-500 to-green-400"
         initial={{ x: "-100%" }}
@@ -101,14 +101,14 @@ export function SessionList() {
       };
 
   return (
-    <div className="flex h-full flex-col border-r border-white/5" style={{ width: "250px" }}>
+    <div className="flex h-full flex-col border-r border-border" style={{ width: "250px" }}>
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-white/5 px-3 py-2">
-        <span className="text-xs font-semibold text-[#B6C7DA]">Sessions</span>
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <span className="text-xs font-semibold text-text-muted">Sessions</span>
         <div className="flex items-center gap-1">
           <button
             onClick={() => fetchSessions()}
-            className="rounded p-1 text-[#6B7280] transition hover:bg-white/5 hover:text-[#B6C7DA]"
+            className="rounded p-1 text-text-muted transition hover:bg-surface-2 hover:text-text-muted"
             title="Rafraichir"
             aria-label="Rafraichir les sessions"
           >
@@ -127,8 +127,8 @@ export function SessionList() {
       </div>
 
       {/* US-003 : Compteur agents actifs */}
-      <div className="flex items-center justify-between border-b border-white/5 px-3 py-1.5">
-        <span className="text-[10px] text-[#6B7280]">
+      <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+        <span className="text-[10px] text-text-muted">
           <span className={runningCount >= maxAgents ? "text-amber-400 font-medium" : "text-purple-400"}>
             {runningCount}/{maxAgents}
           </span>
@@ -137,13 +137,13 @@ export function SessionList() {
       </div>
 
       {/* Connexion status */}
-      <div className="flex items-center gap-1.5 border-b border-white/5 px-3 py-1.5">
+      <div className="flex items-center gap-1.5 border-b border-border px-3 py-1.5">
         <span
           className={`h-1.5 w-1.5 rounded-full ${
             openclawConnected ? "bg-green-400" : "bg-red-400"
           }`}
         />
-        <span className="text-[10px] text-[#6B7280]">
+        <span className="text-[10px] text-text-muted">
           {openclawConnected ? "OpenClaw connecte" : "OpenClaw deconnecte"}
         </span>
       </div>
@@ -152,7 +152,7 @@ export function SessionList() {
       <div className="flex-1 overflow-y-auto">
         {visibleSessions.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-2 px-4 py-8 text-center">
-            <span className="text-xs text-[#6B7280]">Aucune session</span>
+            <span className="text-xs text-text-muted">Aucune session</span>
             <button
               onClick={openNewTask}
               disabled={!openclawConnected || runningCount >= maxAgents}
@@ -175,10 +175,10 @@ export function SessionList() {
                   transition={{ duration: reduceMotion ? 0 : 0.25 }}
                   layout={!reduceMotion}
                   onClick={() => selectSession(session.id)}
-                  className={`w-full border-b border-white/5 px-3 py-2.5 text-left transition ${
+                  className={`w-full border-b border-border px-3 py-2.5 text-left transition ${
                     isActive
                       ? "bg-purple-500/10 border-l-2 border-l-purple-400"
-                      : "hover:bg-white/5"
+                      : "hover:bg-surface-2"
                   }`}
                 >
                   <div className="flex items-center gap-2">
@@ -187,7 +187,7 @@ export function SessionList() {
                         session.status === "running" ? "animate-pulse" : ""
                       }`}
                     />
-                    <span className="flex-1 truncate text-xs font-medium text-[#E6EDF7]">
+                    <span className="flex-1 truncate text-xs font-medium text-text">
                       {session.instruction.length > 60
                         ? session.instruction.slice(0, 60) + "..."
                         : session.instruction}
@@ -222,11 +222,11 @@ export function SessionList() {
                     <span className={`text-[10px] ${statusStyle.text}`}>
                       {statusStyle.label}
                     </span>
-                    <span className="text-[10px] text-[#6B7280]">
+                    <span className="text-[10px] text-text-muted">
                       {formatDuration(session.created_at, session.finished_at)}
                     </span>
                     {session.actions_count > 0 && (
-                      <span className="text-[10px] text-[#6B7280]">
+                      <span className="text-[10px] text-text-muted">
                         {session.actions_count} action{session.actions_count > 1 ? "s" : ""}
                       </span>
                     )}
@@ -238,7 +238,7 @@ export function SessionList() {
                   {/* Result summary pour les sessions terminées */}
                   {session.status === "done" && session.result_summary && (
                     <div className="mt-1 pl-4" title={session.result_summary}>
-                      <span className="text-[10px] leading-tight text-[#6B7280] line-clamp-2">
+                      <span className="text-[10px] leading-tight text-text-muted line-clamp-2">
                         {session.result_summary}
                       </span>
                     </div>

--- a/src/frontend/src/components/atelier/SessionList.tsx
+++ b/src/frontend/src/components/atelier/SessionList.tsx
@@ -144,7 +144,7 @@ export function SessionList() {
           }`}
         />
         <span className="text-[10px] text-text-muted">
-          {openclawConnected ? "OpenClaw connecte" : "OpenClaw deconnecte"}
+          {openclawConnected ? "OpenClaw connecté" : "OpenClaw déconnecté"}
         </span>
       </div>
 

--- a/src/frontend/src/components/calendar/CalendarPanel.tsx
+++ b/src/frontend/src/components/calendar/CalendarPanel.tsx
@@ -233,7 +233,7 @@ export function CalendarPanel({ isOpen, onClose, standalone = false }: CalendarP
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
-      addNotification({ type: 'success', title: 'Export ICS', message: 'Calendrier exporte avec succes' });
+      addNotification({ type: 'success', title: 'Export ICS', message: 'Calendrier exporté avec succès' });
     } catch (err: any) {
       addNotification({ type: 'error', title: 'Erreur export', message: err.message });
     }

--- a/src/frontend/src/components/chat/ChatHeader.tsx
+++ b/src/frontend/src/components/chat/ChatHeader.tsx
@@ -153,7 +153,7 @@ export function ChatHeader({
             title={isMac ? 'Board (⌘D)' : 'Board (Ctrl+D)'}
           >
             <svg width="24" height="24" viewBox="0 0 40 40" fill="none" className="shrink-0">
-              <circle cx="20" cy="20" r="5.5" fill="#E6EDF7" />
+              <circle cx="20" cy="20" r="5.5" fill="currentColor" />
               <circle cx="20" cy="8" r="3" stroke="#22D3EE" strokeWidth="1.5" />
               <circle cx="31.4" cy="16.3" r="3" stroke="#A855F7" strokeWidth="1.5" />
               <circle cx="27.1" cy="29.7" r="3" stroke="#EF4444" strokeWidth="1.5" />

--- a/src/frontend/src/components/chat/EntitySuggestion.tsx
+++ b/src/frontend/src/components/chat/EntitySuggestion.tsx
@@ -58,7 +58,7 @@ function EntityItem({ type, name, subtitle, confidence, onSave, onIgnore }: Enti
       initial={{ opacity: 0, x: -10 }}
       animate={{ opacity: 1, x: 0 }}
       exit={{ opacity: 0, x: 10 }}
-      className="flex items-center gap-3 px-3 py-2 rounded-lg bg-[#1a2444] border border-[#2a3654]"
+      className="flex items-center gap-3 px-3 py-2 rounded-lg bg-surface-elevated border border-border"
     >
       <div className="flex-shrink-0">
         <div className={`p-1.5 rounded-md ${type === 'contact' ? 'bg-cyan-500/20' : 'bg-magenta-500/20'}`}>
@@ -67,14 +67,14 @@ function EntityItem({ type, name, subtitle, confidence, onSave, onIgnore }: Enti
       </div>
 
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-[#E6EDF7] truncate">{name}</p>
+        <p className="text-sm font-medium text-text truncate">{name}</p>
         {subtitle && (
-          <p className="text-xs text-[#B6C7DA] truncate">{subtitle}</p>
+          <p className="text-xs text-text-muted truncate">{subtitle}</p>
         )}
       </div>
 
       <div className="flex items-center gap-1.5">
-        <span className="text-xs text-[#B6C7DA]/60">{confidencePercent}%</span>
+        <span className="text-xs text-text-muted/60">{confidencePercent}%</span>
 
         {status === 'saving' ? (
           <Loader2 className="w-4 h-4 text-cyan-400 animate-spin" />
@@ -89,7 +89,7 @@ function EntityItem({ type, name, subtitle, confidence, onSave, onIgnore }: Enti
             </button>
             <button
               onClick={handleIgnore}
-              className="p-1 rounded hover:bg-red-500/20 text-[#B6C7DA] hover:text-red-400 transition-colors"
+              className="p-1 rounded hover:bg-red-500/20 text-text-muted hover:text-red-400 transition-colors"
               title="Ignorer"
             >
               <X className="w-4 h-4" />
@@ -169,15 +169,15 @@ export function EntitySuggestion({
       transition={{ duration: 0.2, ease: 'easeOut' }}
       className="mt-2 ml-10 overflow-hidden"
     >
-      <div className="p-3 rounded-xl bg-[#131B35] border border-[#2a3654]/50">
+      <div className="p-3 rounded-xl bg-surface border border-border/50">
         {/* Header */}
         <div className="flex items-center justify-between mb-2">
-          <p className="text-xs font-medium text-[#B6C7DA]">
+          <p className="text-xs font-medium text-text-muted">
             {totalCount === 1 ? "J'ai detecte une entite" : `J'ai detecte ${totalCount} entites`}
           </p>
           <button
             onClick={onDismiss}
-            className="text-xs text-[#B6C7DA]/60 hover:text-[#B6C7DA] transition-colors"
+            className="text-xs text-text-muted/60 hover:text-text-muted transition-colors"
           >
             Tout ignorer
           </button>

--- a/src/frontend/src/components/chat/ShortcutsModal.tsx
+++ b/src/frontend/src/components/chat/ShortcutsModal.tsx
@@ -50,7 +50,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: '⌘ + ⇧ + K', description: 'Katia - nouvelle tache' },
       { keys: '⌘ + ⇧ + C', description: 'Calendrier (Google Calendar)' },
       { keys: '⌘ + ⇧ + P', description: 'Nouveau projet' },
-      { keys: '⌘ + ⇧ + F', description: 'Rechercher en memoire' },
+      { keys: '⌘ + ⇧ + F', description: 'Rechercher en mémoire' },
     ],
   },
   {

--- a/src/frontend/src/components/crm/DeliverablesList.tsx
+++ b/src/frontend/src/components/crm/DeliverablesList.tsx
@@ -14,7 +14,7 @@ interface DeliverablesListProps {
 }
 
 const DELIVERABLE_STATUS = {
-  a_faire: { label: 'À faire', icon: Circle, color: 'text-gray-400' },
+  a_faire: { label: 'À faire', icon: Circle, color: 'text-text-muted' },
   en_cours: { label: 'En cours', icon: Clock, color: 'text-blue-400' },
   en_revision: { label: 'En révision', icon: AlertCircle, color: 'text-yellow-400' },
   valide: { label: 'Validé', icon: CheckCircle2, color: 'text-green-400' },

--- a/src/frontend/src/components/crm/PipelineView.tsx
+++ b/src/frontend/src/components/crm/PipelineView.tsx
@@ -31,7 +31,7 @@ import type { ContactResponse } from '../../services/api';
 // Les 7 stages du pipeline
 const PIPELINE_STAGES = [
   { id: 'contact', label: 'Contact', color: 'bg-gray-500' },
-  { id: 'discovery', label: 'Decouverte', color: 'bg-blue-500' },
+  { id: 'discovery', label: 'Découverte', color: 'bg-blue-500' },
   { id: 'proposition', label: 'Proposition', color: 'bg-purple-500' },
   { id: 'signature', label: 'Signature', color: 'bg-yellow-500' },
   { id: 'delivery', label: 'Livraison', color: 'bg-orange-500' },

--- a/src/frontend/src/components/files/FileBrowser.tsx
+++ b/src/frontend/src/components/files/FileBrowser.tsx
@@ -397,7 +397,7 @@ export function FileBrowser({ onFileSelect, onFileIndex, className }: FileBrowse
           <div className="flex flex-col items-center justify-center h-32 text-text-muted">
             <Folder className="w-8 h-8 mb-2 opacity-50" />
             <p className="text-sm">
-              {searchQuery ? 'Aucun resultat' : 'Dossier vide'}
+              {searchQuery ? 'Aucun résultat' : 'Dossier vide'}
             </p>
           </div>
         ) : (

--- a/src/frontend/src/components/guided/ActionCard.tsx
+++ b/src/frontend/src/components/guided/ActionCard.tsx
@@ -54,11 +54,11 @@ export function ActionCard({ icon: Icon, title, description, onClick, index, var
         isPersonnaliser ? 'opacity-50' : 'group-hover:from-accent-cyan/30 group-hover:to-accent-magenta/30',
         'transition-all duration-200'
       )}>
-        <Icon className={cn('w-5 h-5 transition-colors duration-200', isPersonnaliser ? 'text-text-muted' : 'text-accent-cyan group-hover:text-white')} />
+        <Icon className={cn('w-5 h-5 transition-colors duration-200', isPersonnaliser ? 'text-text-muted' : 'text-accent-cyan group-hover:text-text')} />
       </div>
 
       {/* Title */}
-      <h3 className={cn('relative text-sm font-semibold transition-colors duration-200', isPersonnaliser ? 'text-text-muted' : 'text-text group-hover:text-white')}>
+      <h3 className={cn('relative text-sm font-semibold transition-colors duration-200', isPersonnaliser ? 'text-text-muted' : 'text-text group-hover:text-text')}>
         {title}
       </h3>
 

--- a/src/frontend/src/components/guided/ImageGenerationPanel.tsx
+++ b/src/frontend/src/components/guided/ImageGenerationPanel.tsx
@@ -112,7 +112,7 @@ export function ImageGenerationPanel({
             className={cn(
               'absolute top-4 right-4 p-1.5 rounded-lg z-10',
               'text-text-muted hover:text-text',
-              'hover:bg-white/5 transition-colors'
+              'hover:bg-surface-2 transition-colors'
             )}
           >
             <X className="w-4 h-4" />
@@ -195,19 +195,19 @@ export function ImageGenerationPanel({
             animate={{ opacity: 1, y: 0 }}
             className={cn(
               'mb-6 rounded-xl overflow-hidden',
-              'bg-black/20 border border-white/10'
+              'bg-surface-2 border border-border'
             )}
           >
             {/* Loading placeholder */}
             {!imageLoaded && !imageError && (
-              <div className="w-full h-48 flex items-center justify-center bg-black/30">
+              <div className="w-full h-48 flex items-center justify-center bg-surface-2">
                 <Loader2 className="w-8 h-8 text-text-muted animate-spin" />
               </div>
             )}
 
             {/* Error placeholder */}
             {imageError && (
-              <div className="w-full h-48 flex flex-col items-center justify-center bg-black/30 gap-2">
+              <div className="w-full h-48 flex flex-col items-center justify-center bg-surface-2 gap-2">
                 <ImageOff className="w-12 h-12 text-text-muted" />
                 <p className="text-sm text-text-muted">Impossible de charger l'image</p>
                 <p className="text-xs text-text-muted/60 max-w-xs text-center truncate">
@@ -229,7 +229,7 @@ export function ImageGenerationPanel({
             />
 
             {(fileName || fileSize) && (
-              <div className="p-3 bg-black/30 flex items-center justify-between">
+              <div className="p-3 bg-surface-2 flex items-center justify-between">
                 <span className="text-sm text-text-muted truncate">
                   {fileName || 'image.png'}
                 </span>
@@ -250,7 +250,7 @@ export function ImageGenerationPanel({
             animate={{ opacity: 1 }}
             className={cn(
               'mb-6 p-3 rounded-lg',
-              'bg-white/5 border border-white/10'
+              'bg-surface-2 border border-border'
             )}
           >
             <p className="text-xs text-text-muted line-clamp-2 italic">
@@ -266,7 +266,7 @@ export function ImageGenerationPanel({
             animate={{ opacity: 1 }}
             className="mb-6"
           >
-            <div className="h-1.5 bg-white/10 rounded-full overflow-hidden">
+            <div className="h-1.5 bg-surface-2 rounded-full overflow-hidden">
               <motion.div
                 className="h-full bg-gradient-to-r from-accent-cyan to-accent-magenta"
                 initial={{ x: '-100%' }}

--- a/src/frontend/src/components/guided/SkillExecutionPanel.tsx
+++ b/src/frontend/src/components/guided/SkillExecutionPanel.tsx
@@ -123,7 +123,7 @@ export function SkillExecutionPanel({
             className={cn(
               'absolute top-4 right-4 p-1.5 rounded-lg',
               'text-text-muted hover:text-text',
-              'hover:bg-white/5 transition-colors'
+              'hover:bg-surface-2 transition-colors'
             )}
           >
             <X className="w-4 h-4" />
@@ -201,7 +201,7 @@ export function SkillExecutionPanel({
             animate={{ opacity: 1, y: 0 }}
             className={cn(
               'mb-6 p-4 rounded-xl',
-              'bg-white/5 border border-white/10'
+              'bg-surface-2 border border-border'
             )}
           >
             <div className="flex items-center gap-3">
@@ -233,7 +233,7 @@ export function SkillExecutionPanel({
             animate={{ opacity: 1 }}
             className="mb-6"
           >
-            <div className="h-1.5 bg-white/10 rounded-full overflow-hidden">
+            <div className="h-1.5 bg-surface-2 rounded-full overflow-hidden">
               <motion.div
                 className="h-full bg-gradient-to-r from-accent-cyan to-accent-magenta"
                 initial={{ x: '-100%' }}

--- a/src/frontend/src/components/home/DashboardToday.tsx
+++ b/src/frontend/src/components/home/DashboardToday.tsx
@@ -1,227 +1,136 @@
 /**
- * THÉRÈSE v2 - DashboardToday (US-005)
+ * THÉRÈSE v2 - DashboardToday (US-005) — Refonte DA « Équilibre / Signature »
  *
- * Tableau de bord "Ma journée" affiché à l'ouverture de l'application.
- * 4 sections en cards glass : RDV, Tâches urgentes, Factures impayées, Prospects.
- * Design : fond sombre, cards glass, accent couleurs par type.
+ * Tableau de bord "Ma journée" : topbar (salutation + statut), rangée de 4 KPIs,
+ * panneaux Agenda du jour + « Thérèse vous suggère », barre de saisie.
+ * Theme-aware (clair Équilibre par défaut, sombre Signature). Données réelles.
  */
 
 import { useEffect, useState, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import {
   Calendar,
-  CheckSquare,
-  FileText,
+  AlarmClock,
+  Receipt,
   Users,
   ArrowRight,
   MessageSquare,
   Sparkles,
-  Clock,
-  AlertTriangle,
-  MapPin,
+  ShieldCheck,
+  Search,
+  Send,
+  Cpu,
+  AlertCircle,
+  FileText,
 } from 'lucide-react';
 import {
   fetchTodayDashboard,
   type TodayDashboard,
   type DashboardEvent,
-  type DashboardTask,
   type DashboardInvoice,
   type DashboardProspect,
 } from '../../services/api/dashboard';
 import { openPanelWindow } from '../../services/windowManager';
-
-// ============================================================
-// Types
-// ============================================================
 
 interface DashboardTodayProps {
   onDismiss: () => void;
 }
 
 // ============================================================
-// Sub-components
+// Sous-composants
 // ============================================================
 
-function DashboardCard({
-  title,
+function Kpi({
+  k,
   icon: Icon,
-  count,
-  accentColor,
-  items,
-  renderItem,
-  onViewAll,
-  emptyMessage,
+  num,
+  label,
+  sub,
+  onClick,
 }: {
-  title: string;
+  k: 1 | 2 | 3 | 4;
   icon: React.ElementType;
-  count: number;
-  accentColor: string;
-  items: unknown[];
-  renderItem: (item: unknown, index: number) => React.ReactNode;
-  onViewAll: () => void;
-  emptyMessage: string;
+  num: string | number;
+  label: string;
+  sub: string;
+  onClick: () => void;
 }) {
   return (
-    <motion.div
+    <motion.button
+      type="button"
+      onClick={onClick}
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.3 }}
-      className="bg-surface/60 backdrop-blur-xl border border-border/50 rounded-2xl p-5 hover:border-border transition-colors"
+      transition={{ duration: 0.3, delay: k * 0.04 }}
+      className="text-left bg-surface border border-border rounded-xl p-[18px] shadow-[var(--shadow-sm)] hover:shadow-[var(--shadow-md)] transition-shadow"
     >
-      {/* Header */}
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-3">
-          <div
-            className="w-9 h-9 rounded-xl flex items-center justify-center"
-            style={{ backgroundColor: `${accentColor}15` }}
-          >
-            <Icon className="w-4.5 h-4.5" style={{ color: accentColor }} />
-          </div>
-          <div>
-            <h3 className="text-sm font-semibold text-text">{title}</h3>
-            <span className="text-xs text-text-muted">
-              {count === 0 ? 'Aucun' : count} {count > 1 ? 'éléments' : 'élément'}
-            </span>
-          </div>
-        </div>
-        {count > 0 && (
-          <span
-            className="text-xs font-bold px-2 py-1 rounded-full"
-            style={{ backgroundColor: `${accentColor}20`, color: accentColor }}
-          >
-            {count}
-          </span>
-        )}
+      <div
+        className="w-[42px] h-[42px] rounded-[10px] grid place-items-center mb-4"
+        style={{ background: `var(--k${k}bg)`, color: `var(--k${k})` }}
+      >
+        <Icon className="w-[21px] h-[21px]" />
       </div>
-
-      {/* Items */}
-      {items.length === 0 ? (
-        <p className="text-sm text-text-muted italic py-2">{emptyMessage}</p>
-      ) : (
-        <div className="space-y-2">
-          {items.slice(0, 3).map((item, idx) => (
-            <div key={idx} onClick={onViewAll} className="cursor-pointer">
-              {renderItem(item, idx)}
-            </div>
-          ))}
-          {items.length > 3 && (
-            <button
-              onClick={onViewAll}
-              className="flex items-center gap-1.5 text-xs text-accent-cyan hover:text-accent-cyan/80 transition-colors mt-2 group"
-            >
-              <span>Voir les {items.length} éléments</span>
-              <ArrowRight className="w-3 h-3 group-hover:translate-x-0.5 transition-transform" />
-            </button>
-          )}
-        </div>
-      )}
-    </motion.div>
+      <div className="text-[30px] font-extrabold tracking-tight leading-none text-text">{num}</div>
+      <div className="text-[13.5px] text-text-muted mt-1.5 font-medium">{label}</div>
+      <div className="text-xs mt-2 font-semibold" style={{ color: `var(--k${k})` }}>{sub}</div>
+    </motion.button>
   );
 }
 
-function EventItem({ event }: { event: DashboardEvent }) {
+function AgendaRow({ event, k }: { event: DashboardEvent; k: 1 | 2 | 3 | 4 }) {
   const time = event.all_day
-    ? 'Journée entière'
+    ? 'Jour.'
     : event.start_datetime
-      ? new Date(event.start_datetime).toLocaleTimeString('fr-FR', {
-          hour: '2-digit',
-          minute: '2-digit',
-        })
-      : '';
-
+      ? new Date(event.start_datetime).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
+      : '--:--';
   return (
-    <div className="flex items-start gap-3 p-2.5 rounded-xl bg-surface-elevated/50 hover:bg-surface-elevated transition-colors">
-      <Clock className="w-4 h-4 text-accent-cyan mt-0.5 shrink-0" />
-      <div className="min-w-0 flex-1">
-        <p className="text-sm text-text truncate">{event.summary}</p>
-        <div className="flex items-center gap-2 mt-0.5">
-          <span className="text-xs text-text-muted">{time}</span>
-          {event.location && (
-            <span className="text-xs text-text-muted flex items-center gap-0.5">
-              <MapPin className="w-3 h-3" />
-              {event.location}
-            </span>
-          )}
-        </div>
-      </div>
+    <div className="flex items-center gap-3.5 p-3 rounded-[10px] bg-surface-2 border border-border">
+      <span className="text-[13px] font-bold tabular-nums min-w-[46px] text-text">{time}</span>
+      <span className="w-[3px] self-stretch rounded-[3px]" style={{ background: `var(--k${k})` }} />
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-semibold text-text truncate">{event.summary}</span>
+        {event.location && <span className="block text-xs text-text-muted truncate">{event.location}</span>}
+      </span>
     </div>
   );
 }
 
-function TaskItem({ task }: { task: DashboardTask }) {
-  const isOverdue = task.due_date && new Date(task.due_date) < new Date();
-  const priorityColors: Record<string, string> = {
-    urgent: '#EF4444',
-    high: '#F97316',
-    medium: '#EAB308',
-    low: '#6B7280',
-  };
-
+function Suggestion({
+  icon: Icon,
+  title,
+  meta,
+  warn,
+  onClick,
+}: {
+  icon: React.ElementType;
+  title: string;
+  meta: string;
+  warn?: boolean;
+  onClick: () => void;
+}) {
   return (
-    <div className="flex items-start gap-3 p-2.5 rounded-xl bg-surface-elevated/50 hover:bg-surface-elevated transition-colors">
-      <CheckSquare className="w-4 h-4 mt-0.5 shrink-0" style={{ color: priorityColors[task.priority] || '#6B7280' }} />
-      <div className="min-w-0 flex-1">
-        <p className="text-sm text-text truncate">{task.title}</p>
-        <div className="flex items-center gap-2 mt-0.5">
-          <span className="text-xs capitalize" style={{ color: priorityColors[task.priority] || '#6B7280' }}>
-            {task.priority}
-          </span>
-          {isOverdue && (
-            <span className="text-xs text-red-400 flex items-center gap-0.5">
-              <AlertTriangle className="w-3 h-3" />
-              En retard
-            </span>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function InvoiceItem({ invoice }: { invoice: DashboardInvoice }) {
-  return (
-    <div className="flex items-start gap-3 p-2.5 rounded-xl bg-surface-elevated/50 hover:bg-surface-elevated transition-colors">
-      <FileText className="w-4 h-4 text-accent-magenta mt-0.5 shrink-0" />
-      <div className="min-w-0 flex-1">
-        <p className="text-sm text-text truncate">{invoice.invoice_number}</p>
-        <div className="flex items-center gap-2 mt-0.5">
-          <span className="text-xs font-semibold text-accent-magenta">
-            {invoice.total_ttc.toLocaleString('fr-FR', { minimumFractionDigits: 2 })} {invoice.currency === 'EUR' ? '\u20AC' : invoice.currency}
-          </span>
-          {invoice.due_date && (
-            <span className="text-xs text-text-muted">
-              échue le {new Date(invoice.due_date).toLocaleDateString('fr-FR')}
-            </span>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ProspectItem({ prospect }: { prospect: DashboardProspect }) {
-  const daysSince = prospect.last_interaction
-    ? Math.floor((Date.now() - new Date(prospect.last_interaction).getTime()) / (1000 * 60 * 60 * 24))
-    : null;
-
-  return (
-    <div className="flex items-start gap-3 p-2.5 rounded-xl bg-surface-elevated/50 hover:bg-surface-elevated transition-colors">
-      <Users className="w-4 h-4 text-purple-400 mt-0.5 shrink-0" />
-      <div className="min-w-0 flex-1">
-        <p className="text-sm text-text truncate">{prospect.name}</p>
-        <div className="flex items-center gap-2 mt-0.5">
-          {prospect.company && <span className="text-xs text-text-muted">{prospect.company}</span>}
-          {daysSince !== null && (
-            <span className="text-xs text-purple-400">{daysSince}j sans contact</span>
-          )}
-        </div>
-      </div>
-    </div>
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full text-left flex items-start gap-3 p-3 rounded-[10px] border border-border bg-surface-2 hover:border-[color-mix(in_srgb,var(--color-accent)_40%,var(--color-border))] transition-colors"
+    >
+      <span
+        className="w-[30px] h-[30px] rounded-lg grid place-items-center shrink-0"
+        style={warn ? { background: 'var(--k3bg)', color: 'var(--k3)' } : { background: 'var(--color-accent-tint)', color: 'var(--color-accent)' }}
+      >
+        <Icon className="w-4 h-4" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-[13px] font-semibold text-text leading-snug">{title}</span>
+        <span className="block text-[11.5px] text-text-muted mt-0.5">{meta}</span>
+      </span>
+      <ArrowRight className="w-4 h-4 text-text-muted self-center shrink-0" />
+    </button>
   );
 }
 
 // ============================================================
-// Main Component
+// Composant principal
 // ============================================================
 
 export function DashboardToday({ onDismiss }: DashboardTodayProps) {
@@ -230,13 +139,8 @@ export function DashboardToday({ onDismiss }: DashboardTodayProps) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const start = performance.now();
     fetchTodayDashboard()
-      .then((d) => {
-        setData(d);
-        const elapsed = Math.round(performance.now() - start);
-        console.log(`[Dashboard] Chargé en ${elapsed}ms`);
-      })
+      .then(setData)
       .catch((err) => {
         console.warn('[Dashboard] Erreur chargement:', err);
         setError('Impossible de charger le tableau de bord');
@@ -244,30 +148,22 @@ export function DashboardToday({ onDismiss }: DashboardTodayProps) {
       .finally(() => setLoading(false));
   }, []);
 
-  const totalItems = data
-    ? data.summary.events_count + data.summary.tasks_count + data.summary.invoices_count + data.summary.prospects_count
-    : 0;
-
-  const allClear = data !== null && totalItems === 0;
-
   const handleOpenCalendar = useCallback(() => openPanelWindow('calendar'), []);
   const handleOpenTasks = useCallback(() => openPanelWindow('tasks'), []);
   const handleOpenInvoices = useCallback(() => openPanelWindow('invoices'), []);
   const handleOpenCRM = useCallback(() => openPanelWindow('crm'), []);
 
-  // Loading
   if (loading) {
     return (
       <div className="flex-1 flex items-center justify-center">
         <div className="text-center">
-          <div className="w-8 h-8 border-2 border-accent-cyan/30 border-t-accent-cyan rounded-full animate-spin mx-auto" />
+          <div className="w-8 h-8 border-2 border-accent/30 border-t-accent rounded-full animate-spin mx-auto" />
           <p className="text-text-muted text-sm mt-3">Chargement de votre journée...</p>
         </div>
       </div>
     );
   }
 
-  // Error fallback
   if (error || !data) {
     return (
       <div className="flex-1 flex items-center justify-center">
@@ -275,7 +171,7 @@ export function DashboardToday({ onDismiss }: DashboardTodayProps) {
           <p className="text-text-muted text-sm">{error || 'Erreur inconnue'}</p>
           <button
             onClick={onDismiss}
-            className="mt-4 px-4 py-2 bg-accent-cyan/10 text-accent-cyan rounded-xl hover:bg-accent-cyan/20 transition-colors text-sm"
+            className="mt-4 px-4 py-2 bg-accent-tint text-accent rounded-xl hover:brightness-105 transition text-sm"
           >
             Passer au chat
           </button>
@@ -285,115 +181,131 @@ export function DashboardToday({ onDismiss }: DashboardTodayProps) {
   }
 
   const today = new Date();
-  const greeting =
-    today.getHours() < 12
-      ? 'Bonjour'
-      : today.getHours() < 18
-        ? 'Bon après-midi'
-        : 'Bonsoir';
+  const greeting = today.getHours() < 12 ? 'Bonjour' : today.getHours() < 18 ? 'Bon après-midi' : 'Bonsoir';
+  const dateStr = today.toLocaleDateString('fr-FR', { weekday: 'long', day: 'numeric', month: 'long' });
+
+  const overdueTotal = data.overdue_invoices.reduce((s, i) => s + (i.total_ttc || 0), 0);
+
+  // « Thérèse vous suggère » : dérivé des données réelles (max 3)
+  const suggestions: { icon: React.ElementType; title: string; meta: string; warn?: boolean; onClick: () => void }[] = [];
+  const od = data.overdue_invoices[0] as DashboardInvoice | undefined;
+  if (od) {
+    suggestions.push({
+      icon: AlertCircle,
+      warn: true,
+      title: `Relancer la facture ${od.invoice_number}`,
+      meta: `${(od.total_ttc || 0).toLocaleString('fr-FR')} € en attente`,
+      onClick: handleOpenInvoices,
+    });
+  }
+  const ev = data.events[0] as DashboardEvent | undefined;
+  if (ev) {
+    suggestions.push({
+      icon: FileText,
+      title: `Préparer : ${ev.summary}`,
+      meta: ev.location || 'Rendez-vous du jour',
+      onClick: handleOpenCalendar,
+    });
+  }
+  const pr = data.stale_prospects[0] as DashboardProspect | undefined;
+  if (pr) {
+    suggestions.push({
+      icon: Sparkles,
+      title: `Relancer ${pr.name}`,
+      meta: pr.company || 'Prospect à recontacter',
+      onClick: handleOpenCRM,
+    });
+  }
 
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="max-w-3xl mx-auto px-6 py-8">
-        {/* Header */}
-        <motion.div
-          initial={{ opacity: 0, y: -10 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="mb-8"
-        >
-          <h1 className="text-2xl font-bold text-text">
-            {greeting} !
-          </h1>
-          <p className="text-text-muted mt-1">
-            {today.toLocaleDateString('fr-FR', {
-              weekday: 'long',
-              day: 'numeric',
-              month: 'long',
-              year: 'numeric',
-            })}
-          </p>
-        </motion.div>
-
-        {/* All clear message */}
-        {allClear && (
-          <motion.div
-            initial={{ opacity: 0, scale: 0.95 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ delay: 0.2 }}
-            className="bg-emerald-500/10 border border-emerald-500/20 rounded-2xl p-8 text-center mb-8"
-          >
-            <Sparkles className="w-10 h-10 text-emerald-400 mx-auto mb-3" />
-            <h2 className="text-lg font-semibold text-emerald-300">
-              Tout est sous contrôle !
-            </h2>
-            <p className="text-emerald-400/70 text-sm mt-1">
-              Aucun RDV, aucune tâche urgente, aucune facture en retard. Belle journée.
+    <div className="flex-1 min-w-0 overflow-y-auto px-7 py-6">
+      <div className="flex flex-col gap-[22px] max-w-[1180px] mx-auto">
+        {/* Topbar */}
+        <div className="flex items-start gap-4">
+          <div>
+            <h1 className="text-[26px] font-extrabold tracking-tight leading-tight text-text">
+              {greeting} <span className="text-accent">!</span>
+            </h1>
+            <p className="text-sm text-text-muted mt-1.5 first-letter:capitalize">
+              Voici votre journée — {dateStr}.
             </p>
-          </motion.div>
-        )}
-
-        {/* Cards grid */}
-        {!allClear && (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
-            <DashboardCard
-              title="Rendez-vous"
-              icon={Calendar}
-              count={data.summary.events_count}
-              accentColor="#22D3EE"
-              items={data.events}
-              renderItem={(item, idx) => <EventItem key={idx} event={item as DashboardEvent} />}
-              onViewAll={handleOpenCalendar}
-              emptyMessage="Aucun rendez-vous aujourd'hui"
-            />
-            <DashboardCard
-              title="Tâches urgentes"
-              icon={CheckSquare}
-              count={data.summary.tasks_count}
-              accentColor="#F97316"
-              items={data.urgent_tasks}
-              renderItem={(item, idx) => <TaskItem key={idx} task={item as DashboardTask} />}
-              onViewAll={handleOpenTasks}
-              emptyMessage="Aucune tâche urgente"
-            />
-            <DashboardCard
-              title="Factures impayées"
-              icon={FileText}
-              count={data.summary.invoices_count}
-              accentColor="#E11D8D"
-              items={data.overdue_invoices}
-              renderItem={(item, idx) => <InvoiceItem key={idx} invoice={item as DashboardInvoice} />}
-              onViewAll={handleOpenInvoices}
-              emptyMessage="Aucune facture en retard"
-            />
-            <DashboardCard
-              title="Prospects à relancer"
-              icon={Users}
-              count={data.summary.prospects_count}
-              accentColor="#8B5CF6"
-              items={data.stale_prospects}
-              renderItem={(item, idx) => <ProspectItem key={idx} prospect={item as DashboardProspect} />}
-              onViewAll={handleOpenCRM}
-              emptyMessage="Aucun prospect à relancer"
-            />
           </div>
-        )}
+          <div className="ml-auto flex flex-col items-end gap-3">
+            <div className="hidden md:flex items-center gap-2.5 w-[270px] h-10 px-3.5 rounded-full bg-surface border border-border text-text-muted text-[13px]">
+              <Search className="w-4 h-4" />
+              <span className="truncate">Rechercher une conversation, un contact…</span>
+            </div>
+            <div className="flex gap-2">
+              <span className="inline-flex items-center gap-1.5 h-[30px] px-3 rounded-full text-[12.5px] font-medium bg-surface border border-border text-text">
+                <span className="w-[7px] h-[7px] rounded-full" style={{ background: 'var(--color-success)' }} />
+                En ligne
+              </span>
+              <span className="inline-flex items-center gap-1.5 h-[30px] px-3 rounded-full text-[12.5px] font-medium bg-surface border text-accent" style={{ borderColor: 'color-mix(in srgb, var(--color-accent) 45%, transparent)' }}>
+                <ShieldCheck className="w-3.5 h-3.5" />
+                Données locales
+              </span>
+            </div>
+          </div>
+        </div>
 
-        {/* CTA passer au chat */}
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.4 }}
-          className="text-center"
+        {/* KPIs */}
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          <Kpi k={1} icon={Calendar} num={data.summary.events_count} label="Rendez-vous" sub="Aujourd'hui" onClick={handleOpenCalendar} />
+          <Kpi k={2} icon={AlarmClock} num={data.summary.tasks_count} label="Tâches urgentes" sub="À traiter" onClick={handleOpenTasks} />
+          <Kpi k={3} icon={Receipt} num={overdueTotal > 0 ? `${overdueTotal.toLocaleString('fr-FR')} €` : '0 €'} label="Factures impayées" sub={`${data.summary.invoices_count} en attente`} onClick={handleOpenInvoices} />
+          <Kpi k={4} icon={Users} num={data.summary.prospects_count} label="Prospects actifs" sub="Pipeline" onClick={handleOpenCRM} />
+        </div>
+
+        {/* Panneaux */}
+        <div className="grid grid-cols-1 lg:grid-cols-[1.25fr_1fr] gap-4">
+          {/* Agenda */}
+          <section className="bg-surface border border-border rounded-xl p-5 shadow-[var(--shadow-sm)] flex flex-col">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-base font-bold text-text">Agenda du jour</h2>
+              <button onClick={handleOpenCalendar} className="text-[12.5px] text-accent font-semibold hover:underline">Tout voir</button>
+            </div>
+            {data.events.length === 0 ? (
+              <p className="text-sm text-text-muted py-2">Aucun rendez-vous aujourd'hui.</p>
+            ) : (
+              <div className="flex flex-col gap-3">
+                {data.events.slice(0, 4).map((e, i) => (
+                  <AgendaRow key={i} event={e} k={((i % 4) + 1) as 1 | 2 | 3 | 4} />
+                ))}
+              </div>
+            )}
+          </section>
+
+          {/* Suggestions */}
+          <section className="bg-surface border border-border rounded-xl p-5 shadow-[var(--shadow-sm)] flex flex-col">
+            <h2 className="text-base font-bold text-text mb-4">Thérèse vous suggère</h2>
+            {suggestions.length === 0 ? (
+              <div className="flex flex-col items-center justify-center text-center flex-1 py-6">
+                <Sparkles className="w-8 h-8 mb-2" style={{ color: 'var(--color-success)' }} />
+                <p className="text-sm font-semibold text-text">Tout est sous contrôle.</p>
+                <p className="text-xs text-text-muted mt-1">Aucune relance ni urgence en attente.</p>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2.5">
+                {suggestions.map((s, i) => (
+                  <Suggestion key={i} {...s} />
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
+
+        {/* Barre de saisie */}
+        <button
+          onClick={onDismiss}
+          className="flex items-center gap-3 py-3 px-[18px] rounded-full bg-surface border border-border shadow-[var(--shadow-sm)] text-left hover:border-[color-mix(in_srgb,var(--color-ring)_40%,var(--color-border))] transition-colors"
         >
-          <button
-            onClick={onDismiss}
-            className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-accent-cyan/10 to-accent-magenta/10 border border-border/50 rounded-2xl text-text hover:border-accent-cyan/30 transition-all group"
-          >
-            <MessageSquare className="w-4 h-4 text-accent-cyan" />
-            <span className="text-sm font-medium">Passer au chat</span>
-            <ArrowRight className="w-4 h-4 text-text-muted group-hover:translate-x-0.5 transition-transform" />
-          </button>
-        </motion.div>
+          <MessageSquare className="w-4 h-4 text-accent" />
+          <span className="flex-1 text-sm text-text-muted">Demandez à Thérèse…</span>
+          <span className="text-xs text-text-muted hidden sm:flex items-center gap-1.5"><Cpu className="w-3.5 h-3.5" /> Claude Opus</span>
+          <span className="w-9 h-9 rounded-full grid place-items-center bg-accent-fill text-accent-ink shadow-[var(--glow)]">
+            <Send className="w-4 h-4" />
+          </span>
+        </button>
       </div>
     </div>
   );

--- a/src/frontend/src/components/home/DashboardToday.tsx
+++ b/src/frontend/src/components/home/DashboardToday.tsx
@@ -31,6 +31,7 @@ import {
   type DashboardProspect,
 } from '../../services/api/dashboard';
 import { openPanelWindow } from '../../services/windowManager';
+import { useReducedMotion } from '../../stores/accessibilityStore';
 
 interface DashboardTodayProps {
   onDismiss: () => void;
@@ -55,13 +56,14 @@ function Kpi({
   sub: string;
   onClick: () => void;
 }) {
+  const reduced = useReducedMotion();
   return (
     <motion.button
       type="button"
       onClick={onClick}
-      initial={{ opacity: 0, y: 12 }}
+      initial={reduced ? false : { opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.3, delay: k * 0.04 }}
+      transition={reduced ? { duration: 0 } : { duration: 0.3, delay: k * 0.04 }}
       className="text-left bg-surface border border-border rounded-xl p-[18px] shadow-[var(--shadow-sm)] hover:shadow-[var(--shadow-md)] transition-shadow"
     >
       <div

--- a/src/frontend/src/components/home/HomeCommands.tsx
+++ b/src/frontend/src/components/home/HomeCommands.tsx
@@ -384,11 +384,11 @@ export function HomeCommands({ onPromptSelect, onGuidedPanelChange }: HomeComman
 
                   {/* Icon container */}
                   <div className="relative flex items-center justify-center w-10 h-10 rounded-lg mb-3 bg-gradient-to-br from-accent-cyan/20 to-accent-magenta/20 group-hover:from-accent-cyan/30 group-hover:to-accent-magenta/30 transition-all duration-200">
-                    <cat.icon className="w-5 h-5 text-accent-cyan group-hover:text-white transition-colors duration-200" />
+                    <cat.icon className="w-5 h-5 text-accent-cyan group-hover:text-text transition-colors duration-200" />
                   </div>
 
                   {/* Title */}
-                  <h3 className="relative text-sm font-semibold text-text group-hover:text-white transition-colors duration-200">
+                  <h3 className="relative text-sm font-semibold text-text group-hover:text-text transition-colors duration-200">
                     {cat.title}
                   </h3>
 
@@ -420,9 +420,9 @@ export function HomeCommands({ onPromptSelect, onGuidedPanelChange }: HomeComman
               >
                 <div className="absolute inset-0 rounded-xl bg-gradient-to-br from-accent-cyan/5 to-accent-magenta/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                 <div className="relative flex items-center justify-center w-10 h-10 rounded-lg mb-3 bg-gradient-to-br from-accent-cyan/20 to-accent-magenta/20 group-hover:from-accent-cyan/30 group-hover:to-accent-magenta/30 transition-all duration-200">
-                  <BookOpen className="w-5 h-5 text-accent-cyan group-hover:text-white transition-colors duration-200" />
+                  <BookOpen className="w-5 h-5 text-accent-cyan group-hover:text-text transition-colors duration-200" />
                 </div>
-                <h3 className="relative text-sm font-semibold text-text group-hover:text-white transition-colors duration-200">
+                <h3 className="relative text-sm font-semibold text-text group-hover:text-text transition-colors duration-200">
                   Prompts
                 </h3>
                 <p className="relative text-xs mt-1 text-text-muted line-clamp-2">

--- a/src/frontend/src/components/invoices/InvoiceForm.test.tsx
+++ b/src/frontend/src/components/invoices/InvoiceForm.test.tsx
@@ -64,7 +64,7 @@ describe('InvoiceForm décimaux', () => {
     fireEvent.change(screen.getByPlaceholderText('Description'), { target: { value: 'Prestation' } });
     fireEvent.change(screen.getByLabelText('Quantité ligne 1'), { target: { value: '' } });
 
-    fireEvent.click(screen.getByRole('button', { name: /Cre/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Créer/i }));
 
     expect(createInvoiceMock).not.toHaveBeenCalled();
     expect(window.alert).toHaveBeenCalled();

--- a/src/frontend/src/components/invoices/InvoiceForm.tsx
+++ b/src/frontend/src/components/invoices/InvoiceForm.tsx
@@ -183,7 +183,7 @@ export function InvoiceForm({ invoice, onClose, onSave }: InvoiceFormProps) {
     e.preventDefault();
 
     if (!contactId) {
-      addNotification({ type: 'warning', title: 'Champ requis', message: 'Veuillez selectionner un contact' });
+      addNotification({ type: 'warning', title: 'Champ requis', message: 'Veuillez sélectionner un contact' });
       return;
     }
 
@@ -239,11 +239,11 @@ export function InvoiceForm({ invoice, onClose, onSave }: InvoiceFormProps) {
       if (invoice) {
         // Mise a jour
         savedInvoice = await updateInvoice(invoice.id, data);
-        addNotification({ type: 'success', title: 'Facture mise a jour', message: savedInvoice.invoice_number });
+        addNotification({ type: 'success', title: 'Facture mise à jour', message: savedInvoice.invoice_number });
       } else {
         // Creation
         savedInvoice = await createInvoice(data);
-        addNotification({ type: 'success', title: 'Facture creee', message: savedInvoice.invoice_number });
+        addNotification({ type: 'success', title: 'Facture créée', message: savedInvoice.invoice_number });
       }
 
       onSave(savedInvoice);
@@ -260,11 +260,11 @@ export function InvoiceForm({ invoice, onClose, onSave }: InvoiceFormProps) {
     if (!invoice) return;
     try {
       const updatedInvoice = await markInvoicePaid(invoice.id);
-      addNotification({ type: 'success', title: 'Facture payee', message: `${invoice.invoice_number} marquee comme payee` });
+      addNotification({ type: 'success', title: 'Facture payée', message: `${invoice.invoice_number} marquée comme payée` });
       onSave(updatedInvoice);
     } catch (error) {
       console.error('Failed to mark paid:', error);
-      addNotification({ type: 'error', title: 'Erreur', message: 'Impossible de marquer comme payee' });
+      addNotification({ type: 'error', title: 'Erreur', message: 'Impossible de marquer comme payée' });
     }
   }
 
@@ -281,13 +281,13 @@ export function InvoiceForm({ invoice, onClose, onSave }: InvoiceFormProps) {
       addNotification({
         type: 'success',
         title: 'Devis converti en facture',
-        message: `Facture ${newInvoice.invoice_number} creee a partir du devis ${invoice.invoice_number}`,
+        message: `Facture ${newInvoice.invoice_number} créée à partir du devis ${invoice.invoice_number}`,
       });
       onSave(newInvoice);
     } catch (error) {
       console.error('Failed to convert devis:', error);
       const msg = error instanceof Error ? error.message : 'Erreur lors de la conversion';
-      addNotification({ type: 'error', title: 'Conversion echouee', message: msg });
+      addNotification({ type: 'error', title: 'Conversion échouée', message: msg });
     } finally {
       setIsConverting(false);
     }
@@ -651,7 +651,7 @@ export function InvoiceForm({ invoice, onClose, onSave }: InvoiceFormProps) {
                 'focus:outline-none focus:ring-2 focus:ring-accent-cyan',
                 'resize-none'
               )}
-              placeholder="Notes internes ou mentions specifiques..."
+              placeholder="Notes internes ou mentions spécifiques..."
             />
           </div>
 
@@ -788,7 +788,7 @@ export function InvoiceForm({ invoice, onClose, onSave }: InvoiceFormProps) {
               )}
             >
               <Save className="w-4 h-4" />
-              {isSaving ? 'Sauvegarde...' : invoice ? 'Mettre a jour' : 'Creer'}
+              {isSaving ? 'Sauvegarde...' : invoice ? 'Mettre à jour' : 'Créer'}
             </button>
           </div>
         </div>
@@ -813,8 +813,8 @@ export function InvoiceForm({ invoice, onClose, onSave }: InvoiceFormProps) {
             >
               <h3 className="text-lg font-semibold text-text">Convertir en facture ?</h3>
               <p className="text-sm text-text-muted">
-                Une facture sera creee a partir du devis <strong>{invoice?.invoice_number}</strong> avec
-                les memes lignes et montants. Le devis sera marque comme converti.
+                Une facture sera créée à partir du devis <strong>{invoice?.invoice_number}</strong> avec
+                les mêmes lignes et montants. Le devis sera marqué comme converti.
               </p>
               <div className="p-3 rounded-lg bg-surface-elevated/50 border border-border/30 text-sm space-y-1">
                 <p className="text-text-muted">

--- a/src/frontend/src/components/memory/MemoryPanel.tsx
+++ b/src/frontend/src/components/memory/MemoryPanel.tsx
@@ -432,11 +432,11 @@ export function MemoryPanel({ isOpen, onClose, onNewContact, onEditContact }: Me
                           </div>
                           <div>
                             <h3 className="text-base font-semibold text-text">Export RGPD</h3>
-                            <p className="text-sm text-text-muted">Droit de portabilite (Art. 20)</p>
+                            <p className="text-sm text-text-muted">Droit de portabilité (Art. 20)</p>
                           </div>
                         </div>
                         <p className="text-sm text-text-muted mb-4">
-                          Exporter toutes les donnees de <strong>{rgpdAction.contact.first_name} {rgpdAction.contact.last_name}</strong> au format JSON.
+                          Exporter toutes les données de <strong>{rgpdAction.contact.first_name} {rgpdAction.contact.last_name}</strong> au format JSON.
                         </p>
                         <div className="flex gap-2">
                           <Button variant="ghost" className="flex-1" onClick={() => setRgpdAction(null)}>
@@ -469,11 +469,11 @@ export function MemoryPanel({ isOpen, onClose, onNewContact, onEditContact }: Me
                           </div>
                           <div>
                             <h3 className="text-base font-semibold text-text">Anonymisation RGPD</h3>
-                            <p className="text-sm text-text-muted">Droit a l'oubli (Art. 17)</p>
+                            <p className="text-sm text-text-muted">Droit à l'oubli (Art. 17)</p>
                           </div>
                         </div>
                         <p className="text-sm text-text-muted mb-3">
-                          Cette action est <strong>irreversible</strong>. Toutes les donnees personnelles seront remplacees par [ANONYMISE].
+                          Cette action est <strong>irréversible</strong>. Toutes les données personnelles seront remplacées par [ANONYMISE].
                         </p>
                         <div className="mb-4">
                           <label className="block text-sm font-medium text-text mb-1">Raison de l'anonymisation *</label>
@@ -520,7 +520,7 @@ export function MemoryPanel({ isOpen, onClose, onNewContact, onEditContact }: Me
                           </div>
                         </div>
                         <p className="text-sm text-text-muted mb-4">
-                          Le consentement de <strong>{rgpdAction.contact.first_name} {rgpdAction.contact.last_name}</strong> sera prolonge de 3 ans a partir d'aujourd'hui.
+                          Le consentement de <strong>{rgpdAction.contact.first_name} {rgpdAction.contact.last_name}</strong> sera prolongé de 3 ans à partir d'aujourd'hui.
                         </p>
                         <div className="flex gap-2">
                           <Button variant="ghost" className="flex-1" onClick={() => setRgpdAction(null)}>

--- a/src/frontend/src/components/memory/ProjectsKanban.tsx
+++ b/src/frontend/src/components/memory/ProjectsKanban.tsx
@@ -38,8 +38,8 @@ import type { Project } from '../../services/api';
 const STATUS_COLUMNS = [
   { id: 'active', label: 'Actif', icon: Circle, color: 'text-green-400', bg: 'bg-green-500/10', border: 'border-green-500/20' },
   { id: 'on_hold', label: 'En attente', icon: Clock, color: 'text-yellow-400', bg: 'bg-yellow-500/10', border: 'border-yellow-500/20' },
-  { id: 'completed', label: 'Termine', icon: CheckCircle2, color: 'text-blue-400', bg: 'bg-blue-500/10', border: 'border-blue-500/20' },
-  { id: 'cancelled', label: 'Annule', icon: XCircle, color: 'text-red-400', bg: 'bg-red-500/10', border: 'border-red-500/20' },
+  { id: 'completed', label: 'Terminé', icon: CheckCircle2, color: 'text-blue-400', bg: 'bg-blue-500/10', border: 'border-blue-500/20' },
+  { id: 'cancelled', label: 'Annulé', icon: XCircle, color: 'text-red-400', bg: 'bg-red-500/10', border: 'border-red-500/20' },
 ] as const;
 
 const COLUMN_IDS = STATUS_COLUMNS.map((c) => c.id);

--- a/src/frontend/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/frontend/src/components/onboarding/OnboardingWizard.tsx
@@ -181,7 +181,11 @@ export function OnboardingWizard({ isOpen, onComplete }: OnboardingWizardProps) 
                       }}
                       transition={{ duration: 0.2 }}
                       className={`w-8 h-8 rounded-full border-2 flex items-center justify-center ${
-                        index <= currentStep ? 'text-white' : 'text-text-muted'
+                        index < currentStep
+                          ? 'text-white' // sur le fond cyan vif plein : blanc lisible dans les 2 themes
+                          : index === currentStep
+                          ? 'text-text' // sur le fond cyan teinte (20%) : texte token lisible (clair/sombre)
+                          : 'text-text-muted'
                       }`}
                     >
                       {index < currentStep ? (

--- a/src/frontend/src/components/onboarding/SecurityStep.tsx
+++ b/src/frontend/src/components/onboarding/SecurityStep.tsx
@@ -117,8 +117,8 @@ export function SecurityStep({ onNext, onBack }: SecurityStepProps) {
               onClick={() => setExpanded(isExpanded ? null : index)}
               className={cn(
                 'w-full text-left p-3 rounded-xl border transition-all',
-                'hover:bg-white/5',
-                isExpanded ? 'bg-white/5' : 'bg-transparent',
+                'hover:bg-surface-2',
+                isExpanded ? 'bg-surface-2' : 'bg-transparent',
                 'border-border'
               )}
               initial={false}

--- a/src/frontend/src/components/prompts/PromptLibrary.tsx
+++ b/src/frontend/src/components/prompts/PromptLibrary.tsx
@@ -111,7 +111,7 @@ function PromptCard({
     <motion.div
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
-      className="group bg-[#131B35] border border-border/30 rounded-lg p-4 hover:border-accent-cyan/30 hover:shadow-[0_0_15px_rgba(34,211,238,0.08)] transition-all duration-200 cursor-pointer"
+      className="group bg-surface border border-border/30 rounded-lg p-4 hover:border-accent-cyan/30 hover:shadow-[0_0_15px_rgba(34,211,238,0.08)] transition-all duration-200 cursor-pointer"
       onClick={() => setExpanded(!expanded)}
     >
       <div className="flex items-start justify-between gap-3">
@@ -201,7 +201,7 @@ function CategoryAccordion({
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   return (
-    <div className="border border-border/20 rounded-xl overflow-hidden bg-[#0B1226]/80">
+    <div className="border border-border/20 rounded-xl overflow-hidden bg-bg/80">
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="w-full flex items-center gap-3 px-4 py-3 hover:bg-surface/30 transition-colors text-left"
@@ -325,7 +325,7 @@ export function PromptLibrary({ onSelectPrompt, onClose }: PromptLibraryProps) {
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 20 }}
       transition={{ duration: 0.25 }}
-      className="flex flex-col h-full bg-[#0B1226]"
+      className="flex flex-col h-full bg-bg"
     >
       {/* Header */}
       <div className="flex items-center gap-3 px-5 py-4 border-b border-border/30">

--- a/src/frontend/src/components/settings/AccessibilityTab.tsx
+++ b/src/frontend/src/components/settings/AccessibilityTab.tsx
@@ -1,7 +1,7 @@
 // Onglet Accessibilité (A11Y) - Paramètres THÉRÈSE
 // Animations réduites, taille de police, contraste élevé, raccourcis clavier
 
-import { Accessibility } from 'lucide-react';
+import { Accessibility, Sun, Moon } from 'lucide-react';
 import { useAccessibilityStore } from '../../stores/accessibilityStore';
 
 export function AccessibilityTab() {
@@ -15,6 +15,8 @@ export function AccessibilityTab() {
     setHighContrast,
     showKeyboardHints,
     setShowKeyboardHints,
+    theme,
+    setTheme,
   } = useAccessibilityStore();
 
   return (
@@ -29,6 +31,33 @@ export function AccessibilityTab() {
           <p className="text-xs text-text-muted">
             Personnalise l'interface selon tes besoins
           </p>
+        </div>
+      </div>
+
+      {/* Thème clair / sombre (Refonte DA) */}
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-text">Apparence</label>
+        <p className="text-xs text-text-muted">Clair (Équilibre) par défaut, ou sombre (Signature)</p>
+        <div className="flex gap-2" role="radiogroup" aria-label="Thème de l'interface">
+          {([
+            { v: 'light' as const, label: 'Clair', Icon: Sun },
+            { v: 'dark' as const, label: 'Sombre', Icon: Moon },
+          ]).map(({ v, label, Icon }) => (
+            <button
+              key={v}
+              role="radio"
+              aria-checked={theme === v}
+              onClick={() => setTheme(v)}
+              className={`flex-1 py-2 px-3 rounded-lg border text-sm transition-colors flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan ${
+                theme === v
+                  ? 'bg-accent-cyan/20 border-accent-cyan text-accent-cyan'
+                  : 'bg-background/40 border-border/30 text-text-muted hover:border-border'
+              }`}
+            >
+              <Icon className="w-4 h-4" />
+              {label}
+            </button>
+          ))}
         </div>
       </div>
 

--- a/src/frontend/src/components/settings/LLMTab.tsx
+++ b/src/frontend/src/components/settings/LLMTab.tsx
@@ -533,7 +533,7 @@ function ModelSelector({
       <select
         value={selectedModel}
         onChange={(e) => onSelectModel(e.target.value)}
-        className="w-full px-4 py-2.5 bg-background/60 border border-border/50 rounded-lg text-sm text-text focus:outline-none focus:border-accent-cyan/50 transition-colors [&>option]:bg-[#0B1226] [&>option]:text-[#E6EDF7]"
+        className="w-full px-4 py-2.5 bg-background/60 border border-border/50 rounded-lg text-sm text-text focus:outline-none focus:border-accent-cyan/50 transition-colors [&>option]:bg-bg [&>option]:text-text"
         style={{ backgroundColor: 'var(--color-background, #0B1226)', color: 'var(--color-text, #E6EDF7)' }}
       >
         {availableModels.map((model) => (

--- a/src/frontend/src/components/settings/ToolsPanel.tsx
+++ b/src/frontend/src/components/settings/ToolsPanel.tsx
@@ -391,7 +391,7 @@ export function ToolsPanel({ onError }: ToolsPanelProps) {
 
       // Verifier si le serveur a demarre correctement
       if (installed.status === 'error') {
-        onError(installed.name + ' installe mais erreur au demarrage : ' + (installed.error || 'Erreur inconnue. Verifiez que Node.js est installe.'));
+        onError(installed.name + ' installé mais erreur au démarrage : ' + (installed.error || 'Erreur inconnue. Vérifiez que Node.js est installé.'));
       } else if (installed.status !== 'running') {
         // Auto-start seulement si pas deja running (le backend demarre deja)
         try {

--- a/src/frontend/src/components/tasks/TaskKanban.tsx
+++ b/src/frontend/src/components/tasks/TaskKanban.tsx
@@ -269,7 +269,7 @@ function TaskCard({ task, onClick, onStatusChange, isOverlay, dragListeners, mas
     urgent: 'bg-red-500/10 text-red-400 border-red-500/20',
     high: 'bg-orange-500/10 text-orange-400 border-orange-500/20',
     medium: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
-    low: 'bg-gray-500/10 text-gray-400 border-gray-500/20',
+    low: 'bg-gray-500/10 text-text-muted border-gray-500/20',
   };
 
   const isOverdue = task.due_date && new Date(task.due_date) < new Date() && task.status !== 'done';

--- a/src/frontend/src/components/tasks/TaskKanban.tsx
+++ b/src/frontend/src/components/tasks/TaskKanban.tsx
@@ -33,9 +33,9 @@ import * as api from '../../services/api';
 import { useDemoMask } from '../../hooks';
 
 const COLUMNS = [
-  { id: 'todo', label: 'A faire', icon: Circle, color: 'text-text-muted' },
+  { id: 'todo', label: 'À faire', icon: Circle, color: 'text-text-muted' },
   { id: 'in_progress', label: 'En cours', icon: Clock, color: 'text-blue-400' },
-  { id: 'done', label: 'Termine', icon: CheckCircle2, color: 'text-green-400' },
+  { id: 'done', label: 'Terminé', icon: CheckCircle2, color: 'text-green-400' },
 ];
 
 export function TaskKanban() {
@@ -371,7 +371,7 @@ function TaskCard({ task, onClick, onStatusChange, isOverlay, dragListeners, mas
             <button
               onClick={() => onStatusChange('done')}
               className="p-1 hover:bg-green-500/20 rounded transition-colors"
-              title="Marquer termine"
+              title="Marquer terminé"
             >
               <CheckCircle2 className="w-3 h-3 text-green-400" />
             </button>

--- a/src/frontend/src/components/tasks/TaskList.tsx
+++ b/src/frontend/src/components/tasks/TaskList.tsx
@@ -67,7 +67,7 @@ export function TaskList() {
     urgent: 'text-red-400',
     high: 'text-orange-400',
     medium: 'text-blue-400',
-    low: 'text-gray-400',
+    low: 'text-text-muted',
   };
 
   if (filteredTasks.length === 0) {

--- a/src/frontend/src/components/ui/Button.tsx
+++ b/src/frontend/src/components/ui/Button.tsx
@@ -19,7 +19,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           'active:scale-[0.98]',
           // Variants with premium glow effects
           variant === 'primary' &&
-            'bg-accent-cyan text-bg hover:bg-accent-cyan/90 hover:shadow-[0_0_20px_rgba(34,211,238,0.3)] hover:-translate-y-0.5',
+            'bg-accent-fill text-accent-ink hover:brightness-105 hover:shadow-[0_0_20px_rgba(34,211,238,0.3)] hover:-translate-y-0.5',
           variant === 'secondary' &&
             'bg-surface-elevated text-text border border-border hover:bg-surface hover:border-accent-cyan/50 hover:shadow-[0_0_15px_rgba(34,211,238,0.1)]',
           variant === 'ghost' &&

--- a/src/frontend/src/components/ui/Input.tsx
+++ b/src/frontend/src/components/ui/Input.tsx
@@ -27,13 +27,13 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           aria-invalid={error || undefined}
           className={cn(
             'w-full rounded-lg px-3 py-2 text-sm transition-all duration-150',
-            'bg-white/5 border text-text placeholder:text-text-muted/50',
+            'bg-surface-2 border text-text placeholder:text-text-muted/50',
             'focus:outline-none focus:ring-2 focus:ring-offset-0',
             'disabled:opacity-50 disabled:cursor-not-allowed',
             // High contrast support
             'forced-colors:border-[ButtonText] forced-colors:focus:border-[Highlight]',
             // Normal state
-            !error && 'border-white/10 focus:ring-cyan-400 focus:border-cyan-400/50',
+            !error && 'border-border focus:ring-cyan-400 focus:border-cyan-400/50',
             // Error state
             error && 'border-red-500/50 focus:ring-red-400 focus:border-red-400/50',
             // Icon padding

--- a/src/frontend/src/components/ui/NotificationCenter.tsx
+++ b/src/frontend/src/components/ui/NotificationCenter.tsx
@@ -67,9 +67,9 @@ function SourceBadge({ source }: { source: string }) {
     crm: "CRM",
     invoice: "Facture",
     calendar: "Agenda",
-    task: "Tache",
+    task: "Tâche",
     agent: "Agent",
-    system: "Systeme",
+    system: "Système",
   };
   return (
     <span

--- a/src/frontend/src/components/ui/Select.tsx
+++ b/src/frontend/src/components/ui/Select.tsx
@@ -27,13 +27,13 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
         aria-invalid={error || undefined}
         className={cn(
           'w-full rounded-lg px-3 py-2 text-sm transition-all duration-150 appearance-none',
-          'bg-white/5 border text-text',
+          'bg-surface-2 border text-text',
           'focus:outline-none focus:ring-2 focus:ring-offset-0',
           'disabled:opacity-50 disabled:cursor-not-allowed',
           // High contrast support
           'forced-colors:border-[ButtonText] forced-colors:focus:border-[Highlight]',
           // Normal state
-          !error && 'border-white/10 focus:ring-cyan-400 focus:border-cyan-400/50',
+          !error && 'border-border focus:ring-cyan-400 focus:border-cyan-400/50',
           // Error state
           error && 'border-red-500/50 focus:ring-red-400 focus:border-red-400/50',
           // Custom arrow

--- a/src/frontend/src/components/ui/SideToggle.tsx
+++ b/src/frontend/src/components/ui/SideToggle.tsx
@@ -56,7 +56,7 @@ export function SideToggle({ side, isOpen, onClick, label, shortcut }: SideToggl
           absolute inset-0
           bg-gradient-to-b from-surface/60 via-surface/90 to-surface/60
           backdrop-blur-md
-          ${isLeft ? 'border-r' : 'border-l'} border-white/10
+          ${isLeft ? 'border-r' : 'border-l'} border-border
           transition-colors duration-300
           ${isOpen ? 'bg-accent-cyan/10' : ''}
         `}

--- a/src/frontend/src/components/ui/Textarea.tsx
+++ b/src/frontend/src/components/ui/Textarea.tsx
@@ -57,13 +57,13 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         onChange={handleChange}
         className={cn(
           'w-full rounded-lg px-3 py-2 text-sm transition-all duration-150',
-          'bg-white/5 border text-text placeholder:text-text-muted/50',
+          'bg-surface-2 border text-text placeholder:text-text-muted/50',
           'focus:outline-none focus:ring-2 focus:ring-offset-0',
           'disabled:opacity-50 disabled:cursor-not-allowed',
           // High contrast support
           'forced-colors:border-[ButtonText] forced-colors:focus:border-[Highlight]',
           // Normal state
-          !error && 'border-white/10 focus:ring-cyan-400 focus:border-cyan-400/50',
+          !error && 'border-border focus:ring-cyan-400 focus:border-cyan-400/50',
           // Error state
           error && 'border-red-500/50 focus:ring-red-400 focus:border-red-400/50',
           // Auto resize

--- a/src/frontend/src/components/ui/UpdateBanner.tsx
+++ b/src/frontend/src/components/ui/UpdateBanner.tsx
@@ -136,7 +136,7 @@ export function UpdateBanner() {
       // Fallback : demander un redemarrage manuel
       setState({
         phase: 'error',
-        message: 'Veuillez redemarrer THERESE manuellement pour appliquer la mise a jour.',
+        message: 'Veuillez redémarrer THERESE manuellement pour appliquer la mise à jour.',
       });
     }
   }, []);

--- a/src/frontend/src/stores/accessibilityStore.ts
+++ b/src/frontend/src/stores/accessibilityStore.ts
@@ -28,6 +28,11 @@ interface AccessibilityState {
   // Keyboard navigation hints
   showKeyboardHints: boolean;
   setShowKeyboardHints: (show: boolean) => void;
+
+  // Thème clair / sombre (Refonte DA : clair "Équilibre" par défaut, sombre "Signature")
+  theme: 'light' | 'dark';
+  setTheme: (theme: 'light' | 'dark') => void;
+  toggleTheme: () => void;
 }
 
 export const useAccessibilityStore = create<AccessibilityState>()(
@@ -51,6 +56,11 @@ export const useAccessibilityStore = create<AccessibilityState>()(
 
       showKeyboardHints: true,
       setShowKeyboardHints: (show) => set({ showKeyboardHints: show }),
+
+      // Clair par défaut (Équilibre). Sombre = Signature.
+      theme: 'light',
+      setTheme: (theme) => set({ theme }),
+      toggleTheme: () => set((state) => ({ theme: state.theme === 'light' ? 'dark' : 'light' })),
     }),
     {
       name: 'therese-accessibility',

--- a/src/frontend/src/stores/actionsStore.ts
+++ b/src/frontend/src/stores/actionsStore.ts
@@ -40,7 +40,7 @@ function insertResultInChat(task: TaskState): void {
     content = `${header}${task.result}`;
   } else if (task.status === 'error') {
     const partial = task.result?.trim() ? `\n\n${task.result}` : '';
-    const errMsg = task.error?.trim() || 'tache echouee';
+    const errMsg = task.error?.trim() || 'tâche échouée';
     content = `${header}Erreur : ${errMsg}${partial}`;
   }
 

--- a/src/frontend/src/stores/personalisationStore.ts
+++ b/src/frontend/src/stores/personalisationStore.ts
@@ -30,11 +30,11 @@ const DEFAULT_SHORTCUTS: KeyboardShortcut[] = [
   { action: 'newConversation', key: 'N', modifiers: ['cmd'], description: 'Nouvelle conversation' },
   { action: 'toggleSidebar', key: 'B', modifiers: ['cmd'], description: 'Afficher/masquer conversations' },
   { action: 'toggleMemory', key: 'M', modifiers: ['cmd'], description: 'Afficher/masquer espace de travail' },
-  { action: 'toggleBoard', key: 'D', modifiers: ['cmd'], description: 'Board de decision' },
+  { action: 'toggleBoard', key: 'D', modifiers: ['cmd'], description: 'Board de décision' },
   { action: 'commandPalette', key: 'K', modifiers: ['cmd'], description: 'Palette de commandes' },
   { action: 'focusInput', key: '/', modifiers: [], description: 'Focus sur le chat' },
   { action: 'clearChat', key: 'L', modifiers: ['cmd', 'shift'], description: 'Effacer conversation' },
-  { action: 'settings', key: ',', modifiers: ['cmd'], description: 'Parametres' },
+  { action: 'settings', key: ',', modifiers: ['cmd'], description: 'Paramètres' },
   { action: 'newContact', key: 'C', modifiers: ['cmd', 'shift'], description: 'Nouveau contact' },
   { action: 'newProject', key: 'P', modifiers: ['cmd', 'shift'], description: 'Nouveau projet' },
 ];

--- a/src/frontend/src/styles/globals.css
+++ b/src/frontend/src/styles/globals.css
@@ -18,6 +18,11 @@
   --color-text: #101C36;
   --color-text-muted: #5B6A82;
 
+  /* Alias de compatibilité (historiques, ~188 usages) : background = fond appli, text-primary = texte principal.
+     Mêmes valeurs que bg/text, déclinés dans chaque thème ci-dessous. */
+  --color-background: #F3F6FC;
+  --color-text-primary: #101C36;
+
   /* Accents de marque (constants dans les deux modes) */
   --color-accent-cyan: #22D3EE;
   --color-accent-magenta: #E11D8D;
@@ -79,6 +84,10 @@
 
   --color-text: #E6EDF7;
   --color-text-muted: #B6C7DA;
+
+  /* Alias de compatibilité (cf. @theme) */
+  --color-background: #0B1226;
+  --color-text-primary: #E6EDF7;
 
   --color-accent: #22D3EE;
   --color-accent-fill: #22D3EE;
@@ -313,6 +322,10 @@ p, span, div:not(:hover), section { transition: none; }
 
   --color-text: #FFFFFF;
   --color-text-muted: #E0E0E0;
+
+  /* Alias de compatibilité (cf. @theme) */
+  --color-background: #000000;
+  --color-text-primary: #FFFFFF;
 
   --color-accent: #00FFFF;
   --color-accent-fill: #00FFFF;

--- a/src/frontend/src/styles/globals.css
+++ b/src/frontend/src/styles/globals.css
@@ -1,20 +1,36 @@
 @import 'tailwindcss';
 
-/* === THÉRÈSE v2 Design System === */
+/* ============================================================
+   THÉRÈSE v2 — Design System (Refonte DA)
+   Mode CLAIR « Équilibre » par défaut (@theme).
+   Mode SOMBRE « Signature » via [data-theme="dark"].
+   Mode contraste élevé WCAG AAA via [data-high-contrast="true"].
+   ============================================================ */
 
 @theme {
-  /* Colors */
-  --color-bg: #0B1226;
-  --color-surface: #131B35;
-  --color-surface-elevated: #1A2340;
-  --color-border: #2A3550;
+  /* --- Couleurs : défaut = mode clair (Équilibre) --- */
+  --color-bg: #F3F6FC;
+  --color-surface: #FFFFFF;
+  --color-surface-2: #F0F4FB;
+  --color-surface-elevated: #FFFFFF;
+  --color-border: #E2E8F3;
 
-  --color-text: #E6EDF7;
-  --color-text-muted: #B6C7DA;
+  --color-text: #101C36;
+  --color-text-muted: #5B6A82;
 
+  /* Accents de marque (constants dans les deux modes) */
   --color-accent-cyan: #22D3EE;
   --color-accent-magenta: #E11D8D;
+  --color-accent-violet: #A855F7;
 
+  /* Accent d'action (teinté selon le mode) + tint/anneau/texte-sur-accent */
+  --color-accent: #0F8FB3;
+  --color-accent-fill: #22D3EE;
+  --color-accent-ink: #06121F;
+  --color-accent-tint: #DEF4F9;
+  --color-ring: #22D3EE;
+
+  /* Sémantiques */
   --color-success: #10B981;
   --color-warning: #F59E0B;
   --color-error: #EF4444;
@@ -24,16 +40,55 @@
   --font-family-sans: 'Inter', system-ui, -apple-system, sans-serif;
   --font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
 
-  /* Spacing */
+  /* Radius */
   --radius-sm: 0.375rem;
   --radius-md: 0.5rem;
   --radius-lg: 0.75rem;
   --radius-xl: 1rem;
 
-  /* Shadows */
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
+  /* Shadows (clair) */
+  --shadow-sm: 0 1px 2px rgba(16, 28, 54, 0.05);
+  --shadow-md: 0 1px 2px rgba(16, 28, 54, 0.05), 0 10px 24px -10px rgba(16, 28, 54, 0.16);
+  --shadow-lg: 0 10px 30px -8px rgba(16, 28, 54, 0.22);
+}
+
+/* Variables d'effet (non-Tailwind) - défaut clair */
+:root {
+  --glow: none;
+  --glass-bg: rgba(255, 255, 255, 0.72);
+  --glass-border: var(--color-border);
+  --glow-cyan-shadow: 0 1px 2px rgba(16, 28, 54, 0.06);
+  --glow-magenta-shadow: 0 1px 2px rgba(16, 28, 54, 0.06);
+}
+
+/* ============================================================
+   MODE SOMBRE « Signature » — [data-theme="dark"]
+   ============================================================ */
+[data-theme="dark"] {
+  --color-bg: #0B1226;
+  --color-surface: #131B35;
+  --color-surface-2: #0E1630;
+  --color-surface-elevated: #1A2340;
+  --color-border: #2A3550;
+
+  --color-text: #E6EDF7;
+  --color-text-muted: #B6C7DA;
+
+  --color-accent: #22D3EE;
+  --color-accent-fill: #22D3EE;
+  --color-accent-ink: #06121F;
+  --color-accent-tint: rgba(34, 211, 238, 0.12);
+  --color-ring: #22D3EE;
+
+  --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.3);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.3);
   --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.3), 0 4px 6px -4px rgb(0 0 0 / 0.3);
+
+  --glow: 0 0 22px rgba(34, 211, 238, 0.35);
+  --glass-bg: rgba(19, 27, 53, 0.7);
+  --glass-border: #2A3550;
+  --glow-cyan-shadow: 0 0 20px rgba(34, 211, 238, 0.15), 0 0 40px rgba(34, 211, 238, 0.1), inset 0 0 20px rgba(34, 211, 238, 0.05);
+  --glow-magenta-shadow: 0 0 20px rgba(225, 29, 141, 0.15), 0 0 40px rgba(225, 29, 141, 0.1), inset 0 0 20px rgba(225, 29, 141, 0.05);
 }
 
 /* Base styles - fenêtre avec coins arrondis */
@@ -51,7 +106,6 @@ body {
   border-radius: 12px;
 }
 
-/* Root app container avec coins arrondis */
 #root {
   background-color: var(--color-bg);
   border-radius: 12px;
@@ -59,58 +113,43 @@ body {
   height: 100vh;
 }
 
-/* Disable text selection on interactive elements for native feel */
 button,
 [role="button"] {
   user-select: none;
 }
 
 /* Custom scrollbar */
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--color-text-muted); }
 
-::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-::-webkit-scrollbar-thumb {
-  background: var(--color-border);
-  border-radius: 4px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--color-text-muted);
-}
-
-/* Select / Option - contraste thème sombre (BUG-039 listbox blanc sur blanc) */
+/* Select / Option - contraste (BUG-039) */
 select option {
   background-color: var(--color-surface);
   color: var(--color-text);
 }
 
-/* Focus visible styles */
+/* Focus visible */
 :focus-visible {
-  outline: 2px solid var(--color-accent-cyan);
+  outline: 2px solid var(--color-ring);
   outline-offset: 2px;
 }
 
-/* Selection */
 ::selection {
   background: var(--color-accent-cyan);
   color: var(--color-bg);
 }
 
-/* Glassmorphism utility */
+/* Glassmorphism utility (theme-aware) */
 .glass {
-  background: rgba(19, 27, 53, 0.7);
+  background: var(--glass-bg);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--glass-border);
 }
 
-/* Gradient text utility */
+/* Gradient text utility (marque - identique dans les deux modes) */
 .gradient-text {
   background: linear-gradient(135deg, var(--color-accent-cyan), var(--color-accent-magenta));
   -webkit-background-clip: text;
@@ -118,261 +157,171 @@ select option {
   background-clip: text;
 }
 
-/* Prevent drag on images and links in Tauri */
-img,
-a {
-  -webkit-user-drag: none;
-}
+img, a { -webkit-user-drag: none; }
 
-/* Tauri window drag region */
-[data-tauri-drag-region] {
-  -webkit-app-region: drag;
-}
-
+[data-tauri-drag-region] { -webkit-app-region: drag; }
 [data-tauri-drag-region] button,
 [data-tauri-drag-region] a,
-[data-tauri-drag-region] input {
-  -webkit-app-region: no-drag;
-}
+[data-tauri-drag-region] input { -webkit-app-region: no-drag; }
 
-/* === PREMIUM DARK THEME ENHANCEMENTS === */
+/* === EFFETS (theme-aware via variables) === */
 
-/* Glow effects for accent elements */
-.glow-cyan {
-  box-shadow: 0 0 20px rgba(34, 211, 238, 0.15),
-              0 0 40px rgba(34, 211, 238, 0.1),
-              inset 0 0 20px rgba(34, 211, 238, 0.05);
-}
-
-.glow-magenta {
-  box-shadow: 0 0 20px rgba(225, 29, 141, 0.15),
-              0 0 40px rgba(225, 29, 141, 0.1),
-              inset 0 0 20px rgba(225, 29, 141, 0.05);
-}
-
-/* Subtle ambient glow for active states */
+/* Halos d'accent : marqués en sombre, discrets en clair */
+.glow-cyan { box-shadow: var(--glow-cyan-shadow); }
+.glow-magenta { box-shadow: var(--glow-magenta-shadow); }
 .glow-active {
-  box-shadow: 0 0 30px rgba(34, 211, 238, 0.2),
-              0 4px 15px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--glow), 0 4px 15px rgba(0, 0, 0, 0.12);
   transition: box-shadow 0.3s ease;
 }
 
-/* Surface layers with subtle gradients */
+/* Surfaces à dégradé subtil */
 .surface-gradient {
-  background: linear-gradient(
-    180deg,
-    var(--color-surface-elevated) 0%,
-    var(--color-surface) 100%
-  );
+  background: linear-gradient(180deg, var(--color-surface-elevated) 0%, var(--color-surface) 100%);
 }
-
 .surface-radial {
-  background: radial-gradient(
-    ellipse at 50% 0%,
-    rgba(34, 211, 238, 0.03) 0%,
-    transparent 70%
-  ), var(--color-surface);
+  background: radial-gradient(ellipse at 50% 0%, rgba(34, 211, 238, 0.03) 0%, transparent 70%), var(--color-surface);
 }
 
-/* Premium button hover states */
-.btn-glow {
-  position: relative;
-  overflow: hidden;
-  transition: all 0.3s ease;
-}
-
+/* Bouton premium : translation au survol */
+.btn-glow { position: relative; overflow: hidden; transition: all 0.3s ease; }
 .btn-glow::before {
   content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    135deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.05) 50%,
-    transparent 100%
-  );
-  opacity: 0;
-  transition: opacity 0.3s ease;
+  position: absolute; inset: 0;
+  background: linear-gradient(135deg, transparent 0%, rgba(255, 255, 255, 0.05) 50%, transparent 100%);
+  opacity: 0; transition: opacity 0.3s ease;
 }
-
-.btn-glow:hover::before {
-  opacity: 1;
-}
-
+.btn-glow:hover::before { opacity: 1; }
 .btn-glow:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3),
-              0 0 20px rgba(34, 211, 238, 0.1);
+  box-shadow: 0 4px 12px rgba(16, 28, 54, 0.18), var(--glow);
 }
 
-/* Accent border glow on focus */
+/* Anneau d'accent au focus */
 .border-glow:focus-within {
-  border-color: var(--color-accent-cyan);
-  box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.15),
-              0 0 20px rgba(34, 211, 238, 0.1);
+  border-color: var(--color-ring);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-ring) 18%, transparent), var(--glow);
   transition: all 0.2s ease;
 }
 
-/* Code blocks premium styling */
+/* Blocs de code */
 .code-block {
-  background: linear-gradient(
-    135deg,
-    rgba(11, 18, 38, 0.9) 0%,
-    rgba(19, 27, 53, 0.95) 100%
-  );
+  background: var(--color-surface-2);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03),
-              0 4px 12px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-sm);
+}
+[data-theme="dark"] .code-block {
+  background: linear-gradient(135deg, rgba(11, 18, 38, 0.9) 0%, rgba(19, 27, 53, 0.95) 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
-/* Message bubbles */
+/* Bulles de message */
 .message-user {
-  background: linear-gradient(
-    135deg,
-    rgba(34, 211, 238, 0.12) 0%,
-    rgba(34, 211, 238, 0.06) 100%
-  );
-  border: 1px solid rgba(34, 211, 238, 0.2);
+  background: var(--color-accent-tint);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 28%, transparent);
 }
-
 .message-assistant {
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+}
+[data-theme="dark"] .message-user {
+  background: linear-gradient(135deg, rgba(225, 29, 141, 0.12) 0%, rgba(225, 29, 141, 0.06) 100%);
+  border: 1px solid rgba(225, 29, 141, 0.2);
+}
+[data-theme="dark"] .message-assistant {
   background: var(--color-surface-elevated);
   border: 1px solid var(--color-border);
 }
 
-/* Smooth transitions for theme */
+/* Transitions douces globales */
 * {
-  transition-property: background-color, border-color, box-shadow;
+  transition-property: background-color, border-color, box-shadow, color;
   transition-duration: 0.15s;
   transition-timing-function: ease;
 }
+p, span, div:not(:hover), section { transition: none; }
 
-/* Disable transitions on non-interactive elements for performance */
-p, span, div:not(:hover), section {
-  transition: none;
-}
+/* Animations */
+@keyframes spin { to { transform: rotate(360deg); } }
 
-/* F-09 : Spinner de démarrage macOS - animation de rotation */
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-/* Status indicator pulses */
 @keyframes pulse-glow {
-  0%, 100% {
-    opacity: 1;
-    box-shadow: 0 0 8px currentColor;
-  }
-  50% {
-    opacity: 0.7;
-    box-shadow: 0 0 16px currentColor;
-  }
+  0%, 100% { opacity: 1; box-shadow: 0 0 8px currentColor; }
+  50% { opacity: 0.7; box-shadow: 0 0 16px currentColor; }
 }
+.pulse-indicator { animation: pulse-glow 2s ease-in-out infinite; }
 
-.pulse-indicator {
-  animation: pulse-glow 2s ease-in-out infinite;
-}
-
-/* Streaming text cursor */
-@keyframes blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0; }
-}
-
+@keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
 .streaming-cursor::after {
   content: '▋';
   animation: blink 1s step-end infinite;
-  color: var(--color-accent-cyan);
+  color: var(--color-accent);
   margin-left: 2px;
 }
 
 /* Liquid design card hover effect */
-.liquid-card {
-  position: relative;
-  overflow: hidden;
-}
-
+.liquid-card { position: relative; overflow: hidden; }
 .liquid-card::after {
   content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(
-    circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
-    rgba(34, 211, 238, 0.08) 0%,
-    transparent 50%
-  );
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  pointer-events: none;
+  position: absolute; inset: 0;
+  background: radial-gradient(circle at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(34, 211, 238, 0.08) 0%, transparent 50%);
+  opacity: 0; transition: opacity 0.3s ease; pointer-events: none;
 }
+.liquid-card:hover::after { opacity: 1; }
 
-.liquid-card:hover::after {
-  opacity: 1;
-}
-
-/* Input field premium styling */
+/* Champ de saisie premium */
 .input-premium {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   transition: all 0.2s ease;
 }
-
-.input-premium:hover {
-  border-color: rgba(34, 211, 238, 0.3);
-}
-
+.input-premium:hover { border-color: color-mix(in srgb, var(--color-ring) 35%, var(--color-border)); }
 .input-premium:focus {
-  border-color: var(--color-accent-cyan);
+  border-color: var(--color-ring);
   background: var(--color-surface-elevated);
-  box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.1),
-              inset 0 1px 2px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-ring) 12%, transparent);
 }
 
 /* Divider with gradient */
 .divider-gradient {
   height: 1px;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    var(--color-border) 20%,
-    var(--color-border) 80%,
-    transparent 100%
-  );
+  background: linear-gradient(90deg, transparent 0%, var(--color-border) 20%, var(--color-border) 80%, transparent 100%);
 }
 
-/* ============================================
+/* ============================================================
    HIGH CONTRAST MODE - WCAG AAA (ratio > 10:1)
-   ============================================ */
+   S'applique par-dessus le thème clair ou sombre.
+   ============================================================ */
 [data-high-contrast="true"] {
   --color-bg: #000000;
   --color-surface: #0A0A0A;
+  --color-surface-2: #0A0A0A;
   --color-surface-elevated: #141414;
   --color-border: #FFFFFF;
 
   --color-text: #FFFFFF;
   --color-text-muted: #E0E0E0;
 
+  --color-accent: #00FFFF;
+  --color-accent-fill: #00FFFF;
   --color-accent-cyan: #00FFFF;
   --color-accent-magenta: #FF00FF;
+  --color-accent-tint: #000000;
+  --color-ring: #FFFFFF;
 
   --color-success: #00FF00;
   --color-warning: #FFFF00;
   --color-error: #FF0000;
   --color-info: #00BFFF;
+
+  --glow: none;
+  --glass-bg: rgba(0, 0, 0, 0.95);
+  --glass-border: #FFFFFF;
 }
 
-[data-high-contrast="true"] .glass {
-  background: rgba(0, 0, 0, 0.95);
-  border: 2px solid #FFFFFF;
-}
-
+[data-high-contrast="true"] .glass { border-width: 2px; }
 [data-high-contrast="true"] button,
-[data-high-contrast="true"] a {
-  border: 1px solid currentColor;
-}
-
+[data-high-contrast="true"] a { border: 1px solid currentColor; }
 [data-high-contrast="true"] :focus-visible {
   outline: 3px solid #FFFFFF;
   outline-offset: 3px;

--- a/src/frontend/src/styles/globals.css
+++ b/src/frontend/src/styles/globals.css
@@ -59,6 +59,12 @@
   --glass-border: var(--color-border);
   --glow-cyan-shadow: 0 1px 2px rgba(16, 28, 54, 0.06);
   --glow-magenta-shadow: 0 1px 2px rgba(16, 28, 54, 0.06);
+
+  /* Accents KPI / catégories (clair Équilibre) */
+  --k1: #0F8FB3; --k1bg: #DEF4F9;
+  --k2: #B45309; --k2bg: #FAEFDC;
+  --k3: #BE1A72; --k3bg: #FBE3F0;
+  --k4: #7C3AED; --k4bg: #F0E9FC;
 }
 
 /* ============================================================
@@ -89,6 +95,12 @@
   --glass-border: #2A3550;
   --glow-cyan-shadow: 0 0 20px rgba(34, 211, 238, 0.15), 0 0 40px rgba(34, 211, 238, 0.1), inset 0 0 20px rgba(34, 211, 238, 0.05);
   --glow-magenta-shadow: 0 0 20px rgba(225, 29, 141, 0.15), 0 0 40px rgba(225, 29, 141, 0.1), inset 0 0 20px rgba(225, 29, 141, 0.05);
+
+  /* Accents KPI / catégories (sombre Signature) */
+  --k1: #22D3EE; --k1bg: rgba(34, 211, 238, 0.13);
+  --k2: #F59E0B; --k2bg: rgba(245, 158, 11, 0.13);
+  --k3: #E11D8D; --k3bg: rgba(225, 29, 141, 0.13);
+  --k4: #A855F7; --k4bg: rgba(168, 85, 247, 0.13);
 }
 
 /* Base styles - fenêtre avec coins arrondis */


### PR DESCRIPTION
## Refonte DA — Phase 1 : fondation thème light/dark

Handoff Claude Design : tu as retenu **clair = Équilibre (par défaut)**, **sombre = Signature**. Cette PR pose le système de thème, appliqué aux composants existants.

- **globals.css** : tokens clair Équilibre par défaut (`@theme`), override `[data-theme="dark"]` Signature (navy + glow). Effets (glass, glow, bulles, code-block) theme-aware via variables. Mode contraste élevé conservé par-dessus.
- **accessibilityStore** : préférence `theme` (clair par défaut) + `setTheme`/`toggleTheme`, persistée.
- **App.tsx** : `data-theme` sur `<html>` (chrome de fenêtre compris) + div racine.
- **Button** : variant `primary` → `bg-accent-fill`/`text-accent-ink` (lisible clair ET sombre).
- **AccessibilityTab** : toggle Clair/Sombre (soleil/lune).

### Vérifications
tsc 0 erreur · vite build OK · eslint 27/27 · **121 tests vitest verts**.

### Suite (phases à venir)
- Phase 2 : nouvelle sidebar 234px + chrome de fenêtre selon la DA.
- Phase 3 : refonte pixel-près des 4 écrans (tableau de bord, conversation, board, suivi de dossiers) + polish light-mode par composant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)