### PR TITLE
fix(chat): BUG-107 activer une conversation affiche toujours le chat (Capov)

### DIFF
--- a/src/frontend/src/stores/actionsStore.insertResult.test.ts
+++ b/src/frontend/src/stores/actionsStore.insertResult.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { insertResultInChat } from './actionsStore';
+import { useChatStore } from './chatStore';
+import { useNavigationStore } from './navigationStore';
+import type { TaskState } from '../services/api/actions';
+
+/**
+ * BUG-107 (Capov, 0.21.0) — volet « prep-RDV » : une action terminée annonçait
+ * « Résultat inséré dans le chat » mais, lancée depuis l'Accueil, le résultat
+ * partait dans une conversation invisible (la vue restait sur l'Accueil).
+ */
+const completedTask = (id: string): TaskState => ({
+  task_id: id,
+  agent_id: 'prep-rdv',
+  agent_name: 'Préparation RDV',
+  status: 'completed',
+  params: {},
+  steps: [],
+  result: 'Brief de rendez-vous : préparer la réunion avec Sandrine Joly.',
+  created_at: '',
+  started_at: null,
+  completed_at: null,
+  error: null,
+  progress: 1,
+});
+
+describe('actionsStore.insertResultInChat (BUG-107 / prep-RDV)', () => {
+  beforeEach(() => {
+    useNavigationStore.setState({ activeView: 'home', history: [] });
+    useChatStore.setState({ conversations: [], currentConversationId: null });
+  });
+
+  it('insère le résultat dans le chat ET ramène la vue sur le chat', () => {
+    insertResultInChat(completedTask('task-bug107-insert'));
+
+    const conv = useChatStore.getState().currentConversation();
+    expect(conv?.messages.at(-1)?.content).toContain('Brief de rendez-vous');
+    expect(useNavigationStore.getState().activeView).toBe('chat');
+  });
+});

--- a/src/frontend/src/stores/actionsStore.ts
+++ b/src/frontend/src/stores/actionsStore.ts
@@ -13,6 +13,7 @@ import {
   cancelTask,
 } from '../services/api/actions';
 import { useChatStore } from './chatStore';
+import { useNavigationStore } from './navigationStore';
 
 /**
  * Set d'idempotence : empeche d'inserer plusieurs fois le resultat
@@ -30,7 +31,7 @@ const insertedTaskIds = new Set<string>();
  * Pour status `error` : insere un message d'erreur clair (resultat
  * partiel inclus s'il existe).
  */
-function insertResultInChat(task: TaskState): void {
+export function insertResultInChat(task: TaskState): void {
   if (insertedTaskIds.has(task.task_id)) return;
 
   const header = task.agent_name ? `**${task.agent_name}**\n\n` : '';
@@ -47,6 +48,9 @@ function insertResultInChat(task: TaskState): void {
   if (!content) return;
   insertedTaskIds.add(task.task_id);
   useChatStore.getState().addMessage({ role: 'assistant', content });
+  // BUG-107 : le résultat d'une action lancée depuis l'Accueil partait dans une
+  // conversation invisible. On ramène la vue sur le chat pour le rendre visible.
+  useNavigationStore.getState().setView('chat');
 }
 
 interface ActionsState {

--- a/src/frontend/src/stores/chatStore.navigation.test.ts
+++ b/src/frontend/src/stores/chatStore.navigation.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useChatStore } from './chatStore';
+import { useNavigationStore } from './navigationStore';
+
+/**
+ * BUG-107 (Capov, 0.21.0) : depuis la vue Accueil (introduite en 0.21), créer ou
+ * sélectionner une conversation ne ramenait pas la zone centrale sur le chat.
+ * Symptômes : Cmd+N « n'apparaît pas », clic sur l'historique « n'ouvre rien ».
+ * Cause racine : aucun point central ne garantissait `activeView === 'chat'`
+ * lors de l'activation d'une conversation. On verrouille ça au niveau du store.
+ */
+describe('chatStore — activer une conversation affiche le chat (BUG-107)', () => {
+  beforeEach(() => {
+    useNavigationStore.setState({ activeView: 'home', history: [] });
+    useChatStore.setState({ conversations: [], currentConversationId: null });
+  });
+
+  it('createConversation ramène la vue active sur le chat depuis l’Accueil', () => {
+    expect(useNavigationStore.getState().activeView).toBe('home');
+    useChatStore.getState().createConversation();
+    expect(useNavigationStore.getState().activeView).toBe('chat');
+  });
+
+  it('loadConversation ramène la vue active sur le chat depuis l’Accueil', () => {
+    const id = useChatStore.getState().createConversation();
+    // Re-simule un retour sur l'Accueil avant la sélection dans la sidebar.
+    useNavigationStore.setState({ activeView: 'home', history: [] });
+    useChatStore.getState().loadConversation(id);
+    expect(useNavigationStore.getState().activeView).toBe('chat');
+  });
+});

--- a/src/frontend/src/stores/chatStore.ts
+++ b/src/frontend/src/stores/chatStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { generateId } from '../lib/utils';
+import { useNavigationStore } from './navigationStore';
 
 import type { DetectedEntities } from '../services/api';
 
@@ -111,11 +112,19 @@ export const useChatStore = create<ChatStore>()(
           conversations: [newConversation, ...state.conversations],
           currentConversationId: id,
         }));
+        // BUG-107 : activer une conversation doit toujours afficher le chat.
+        // Avant la vue Accueil (0.21), l'app était toujours sur 'chat' et ce
+        // couplage était implicite ; depuis, créer une conversation depuis
+        // l'Accueil laissait la zone centrale sur l'Accueil (Cmd+N « invisible »).
+        useNavigationStore.getState().setView('chat');
         return id;
       },
 
       loadConversation: (id) => {
         set({ currentConversationId: id });
+        // BUG-107 : sélectionner une conversation (sidebar, Accueil) doit ramener
+        // la zone centrale sur le chat, sinon « rien ne s'ouvre » depuis l'Accueil.
+        useNavigationStore.getState().setView('chat');
       },
 
       deleteConversation: (id) => {


### PR DESCRIPTION
## Contexte

Bug remonté par Capov sur la 0.21.0 (macOS Tahoe) : « le chat ne s'ouvre plus ». Après une préparation de RDV depuis un nouveau contact CRM, cliquer sur l'historique dans la sidebar n'ouvrait rien, et les Cmd+N créaient des conversations vides qui s'empilaient sans s'afficher.

## Cause racine

Depuis la vue Accueil introduite en 0.21, **activer une conversation ne ramenait jamais la zone centrale sur le chat**. 8 points d'entrée créaient/sélectionnaient une conversation, mais seuls 3 basculaient `activeView` vers `chat`. Avant la 0.21, l'app était toujours sur le chat, ce qui masquait le défaut. Le backend répondait bien (messages en 200, confirmé par le sidecar) : bug 100 % frontend.

## Fix (à la racine, pas 8 rustines)

`chatStore.createConversation`/`loadConversation` et `actionsStore.insertResultInChat` basculent désormais toujours `activeView = 'chat'`.

## Tests

3 tests de régression (rouge→vert), suite frontend complète verte, build OK.

Generated with Claude Code (https://claude.com/claude-code)
