### PR TITLE
Sprint 0 remédiation audit UltraJury : 5 P0 + 2 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/licence-AGPL--3.0-blue.svg" alt="AGPL-3.0 License" /></a>
   <a href="https://github.com/ludovicsanchez38-creator/Synoptia-THERESE/actions"><img src="https://img.shields.io/github/actions/workflow/status/ludovicsanchez38-creator/Synoptia-THERESE/ci.yml?branch=main&label=CI" alt="CI" /></a>
-  <img src="https://img.shields.io/badge/version-0.7.0--alpha-orange" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.21.0--alpha-orange" alt="Version" />
 </p>
 
 <p align="center">
@@ -31,7 +31,7 @@
 - **18 skills intégrés** - Word, Excel, PowerPoint, emails pro, posts LinkedIn, propositions commerciales, analyses PDF/web, planification projets/semaine/objectifs
 - **Recherche web** - Brave Search, SearXNG (auto-hébergeable) ou DuckDuckGo
 - **Dictée vocale** - Parle, THÉRÈSE écrit
-- **Données locales** - Ton contexte stocké et chiffré sur ta machine. Les réponses passent par le provider IA de ton choix.
+- **Données locales** - Ton contexte reste sur ta machine, jamais envoyé à un serveur Synoptïa. Tes clés API sont chiffrées via le trousseau de ton système. Les réponses passent par le provider IA de ton choix.
 - **Atelier IA (v0.5)** - Deux agents embarqués qui améliorent l'app pour toi (voir ci-dessous)
 - **THERESE.md** - Fichier de contexte personnel éditable depuis les Paramètres
 
@@ -46,7 +46,7 @@ THÉRÈSE embarque deux agents IA open source qui travaillent ensemble :
 
 **Open source** : les prompts des agents (`SOUL.md`) sont livrés avec le code. Tu peux les personnaliser dans `~/.therese/agents/`. Tu fournis ta propre clé API (BYOK), on ne livre aucun token.
 
-**Compatible OpenClaw** : le format de configuration (agent.json + SOUL.md) est compatible avec [OpenClaw](https://github.com/anthropics/openclaw) (MIT).
+**Compatible OpenClaw** : le format de configuration (agent.json + SOUL.md) est compatible avec [OpenClaw](https://github.com/openclaw/openclaw) (MIT).
 
 ## Télécharger (alpha)
 

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -532,10 +532,19 @@ async def auth_middleware(request: Request, call_next):
         return await call_next(request)
 
     # Endpoints exemptés
+    # US-005 : /api/shutdown est appelé à la fermeture par Tauri (TcpStream brut,
+    # lib.rs) et par UpdateBanner, qui n'ont pas le token de session en main ;
+    # sans exemption, ces appels repartaient en 401 et le shutdown graceful ne
+    # s'exécutait jamais (force-kill + verrou backend.exe à l'update Windows).
+    # Risque CSRF accepté : impact limité à fermer l'app (nuisance récupérable,
+    # pas de fuite), et atténué par Private Network Access côté navigateur.
+    # Durcissement possible : faire signer l'appel par les 2 appelants (token
+    # lu depuis ~/.therese/.session_token) — nécessite un changement Rust testé.
     exempt_paths = [
         "/api/health", "/api/auth/token",
         "/api/email/auth/callback-redirect",
         "/api/crm/sync/callback",
+        "/api/shutdown",
         "/docs", "/redoc", "/openapi.json", "/health",
     ]
     if any(request.url.path.startswith(p) for p in exempt_paths):

--- a/src/backend/app/models/schemas.py
+++ b/src/backend/app/models/schemas.py
@@ -50,13 +50,14 @@ class ChatResponse(BaseModel):
 class StreamChunk(BaseModel):
     """Streaming response chunk."""
 
-    type: Literal["text", "done", "error", "status", "tool_result", "entities_detected", "skill_file"] = "text"
+    type: Literal["text", "done", "error", "status", "tool_result", "entities_detected", "skill_file", "confirmation_required"] = "text"
     content: str = ""
     conversation_id: str | None = None
     message_id: str | None = None
     entities: dict | None = None
     tool_name: str | None = None  # For tool_result type
     skill_file: dict | None = None  # For skill_file type (auto-detected skill execution)
+    confirmation: dict | None = None  # US-002 : action sensible en attente de validation
     provider: str | None = None  # P0-IA-3 : provider LLM utilisé (event done)
 
 

--- a/src/backend/app/routers/chat.py
+++ b/src/backend/app/routers/chat.py
@@ -45,6 +45,11 @@ from app.services.qdrant import get_qdrant_service
 from app.services.skills.base import SkillExecuteRequest
 from app.services.slash_commands import execute_slash_command, parse_slash_command
 from app.services.token_tracker import detect_uncertainty, get_token_tracker
+from app.services.tool_confirmations import (
+    pop_pending,
+    register_pending,
+    requires_confirmation,
+)
 from app.services.web_search import (
     BROWSER_TOOL,
     WEB_SEARCH_TOOL,
@@ -1132,6 +1137,34 @@ async def _execute_tools_and_continue(
     for tc in allowed_calls:
         logger.info(f"Executing tool: {tc.name} with args: {tc.arguments}")
 
+        # US-002 : les outils sensibles (envoi de mail) ne s'exécutent jamais
+        # automatiquement sur décision du LLM. On met l'action en attente et on
+        # demande validation à l'utilisateur ; l'exécution réelle a lieu via
+        # POST /api/chat/confirm-tool une fois l'action confirmée.
+        if requires_confirmation(tc.name):
+            confirmation_id = register_pending(tc.name, tc.arguments)
+            confirm_chunk = StreamChunk(
+                type="confirmation_required",
+                conversation_id=conversation_id,
+                tool_name=tc.name,
+                confirmation={
+                    "confirmation_id": confirmation_id,
+                    "tool_name": tc.name,
+                    "arguments": tc.arguments,
+                },
+            )
+            yield f"data: {json.dumps(confirm_chunk.model_dump())}\n\n"
+            tool_results.append(ToolResult(
+                tool_call_id=tc.id,
+                result=(
+                    "Action préparée et en attente de validation de l'utilisateur. "
+                    "NE PAS la considérer comme exécutée : l'utilisateur doit confirmer."
+                ),
+                is_error=False,
+            ))
+            exec_records.append((tc.name, "en attente de confirmation utilisateur", False))
+            continue
+
         # Execute based on tool type
         if tc.name == "web_search":
             # Built-in web search tool
@@ -1352,6 +1385,40 @@ async def _execute_tools_and_continue(
                 conversation_id=conversation_id,
             )
             yield f"data: {json.dumps(error_data.model_dump())}\n\n"
+
+
+# ============================================================
+# US-002 - Confirmation d'actions sensibles
+# ============================================================
+
+
+class ConfirmToolRequest(BaseModel):
+    """Validation (ou annulation) d'une action sensible mise en attente."""
+
+    confirmation_id: str
+    approved: bool
+
+
+@router.post("/confirm-tool")
+async def confirm_tool(
+    request: ConfirmToolRequest,
+    session: AsyncSession = Depends(get_session),
+):
+    """Exécute (ou annule) une action sensible (ex. send_email) après validation
+    explicite de l'utilisateur. L'action a été mise en attente par la boucle
+    d'outils, qui ne l'exécute jamais automatiquement (US-002)."""
+    action = pop_pending(request.confirmation_id)
+    if action is None:
+        raise HTTPException(
+            status_code=404, detail="Action introuvable ou déjà traitée"
+        )
+
+    tool_name, arguments = action
+    if not request.approved:
+        return {"status": "cancelled", "tool_name": tool_name}
+
+    result = await execute_workspace_tool(tool_name, arguments, session)
+    return {"status": "executed", "tool_name": tool_name, "result": result}
 
 
 # ============================================================

--- a/src/backend/app/routers/dashboard.py
+++ b/src/backend/app/routers/dashboard.py
@@ -177,7 +177,7 @@ async def get_today_dashboard(session: AsyncSession = Depends(get_session)):
         for p in prospects:
             stale_prospects.append({
                 "id": p.id,
-                "name": p.name,
+                "name": p.display_name,
                 "company": p.company,
                 "stage": p.stage,
                 "email": p.email,

--- a/src/backend/app/routers/rgpd.py
+++ b/src/backend/app/routers/rgpd.py
@@ -12,7 +12,14 @@ import logging
 from datetime import UTC, datetime, timedelta
 
 from app.models.database import get_session
-from app.models.entities import Activity, Contact, Deliverable, Project, Task
+from app.models.entities import (
+    Activity,
+    Contact,
+    Deliverable,
+    EmailMessage,
+    Project,
+    Task,
+)
 from app.models.schemas import (
     RGPDAnonymizeRequest,
     RGPDAnonymizeResponse,
@@ -217,6 +224,14 @@ async def anonymize_contact(
             await session.delete(deliv)
         # Delete project
         await session.delete(project)
+
+    # RGPD-1 (US-003) : effacer les emails liés au contact (art. 17). Ils
+    # restaient en base avec le contact_id, contenu intégral inclus.
+    result = await session.execute(
+        select(EmailMessage).where(EmailMessage.contact_id == contact_id)
+    )
+    for email_msg in result.scalars().all():
+        await session.delete(email_msg)
 
     # Log anonymization activity
     anonymization_log = Activity(

--- a/src/backend/app/services/email_response_generator.py
+++ b/src/backend/app/services/email_response_generator.py
@@ -13,6 +13,45 @@ from app.services.user_profile import get_cached_profile
 logger = logging.getLogger(__name__)
 
 
+def build_email_system_prompt(
+    user_name: str,
+    user_role: str,
+    user_company: str,
+    tone: str = "formal",
+    length: str = "medium",
+) -> str:
+    """Construit le prompt système du générateur de réponses email.
+
+    Extrait pour être testable (US-003). La consigne « ne mentionne jamais que
+    tu es une IA » a été retirée (IA Act art. 50) ; la signature au nom de
+    l'utilisateur et la protection des données CRM sont conservées.
+    """
+    tone_instructions = {
+        "formal": "Ton professionnel et formel. Vouvoiement. Formules de politesse complètes.",
+        "friendly": "Ton amical et décontracté. Tutoiement si approprié. Style direct et chaleureux.",
+        "neutral": "Ton équilibré et courtois. Ni trop formel ni trop familier.",
+    }
+    length_instructions = {
+        "short": "Réponse courte et concise (2-3 phrases maximum).",
+        "medium": "Réponse de longueur moyenne (1 paragraphe).",
+        "detailed": "Réponse détaillée et complète (2-3 paragraphes).",
+    }
+
+    return f"""Tu es l'assistant email de {user_name}, {user_role} chez {user_company}.
+
+Tu rédiges des réponses professionnelles et pertinentes aux emails reçus.
+
+{tone_instructions.get(tone, tone_instructions['neutral'])}
+{length_instructions.get(length, length_instructions['medium'])}
+
+Règles importantes :
+- Signe toujours avec le nom de {user_name} (pas "Assistant IA")
+- Réponds directement aux questions posées
+- Sois concret et actionnable
+- Propose des créneaux/dates si pertinent
+- Ne mentionne JAMAIS le score CRM, le stage commercial, les notes internes, les informations de pipeline, ni aucune donnée confidentielle issue du CRM dans ta réponse."""
+
+
 class EmailResponseGenerator:
     """Génère des réponses emails via LLM."""
 
@@ -50,34 +89,10 @@ class EmailResponseGenerator:
         user_company = (profile.company if profile else None) or 'Synoptïa'
         user_role = (profile.role if profile else None) or 'Consultant IA'
 
-        # Construire le prompt selon le ton
-        tone_instructions = {
-            'formal': "Ton professionnel et formel. Vouvoiement. Formules de politesse complètes.",
-            'friendly': "Ton amical et décontracté. Tutoiement si approprié. Style direct et chaleureux.",
-            'neutral': "Ton équilibré et courtois. Ni trop formel ni trop familier."
-        }
-
-        length_instructions = {
-            'short': "Réponse courte et concise (2-3 phrases maximum).",
-            'medium': "Réponse de longueur moyenne (1 paragraphe).",
-            'detailed': "Réponse détaillée et complète (2-3 paragraphes)."
-        }
-
-        # Prompt système
-        system_prompt = f"""Tu es l'assistant email de {user_name}, {user_role} chez {user_company}.
-
-Tu rédiges des réponses professionnelles et pertinentes aux emails reçus.
-
-{tone_instructions.get(tone, tone_instructions['neutral'])}
-{length_instructions.get(length, length_instructions['medium'])}
-
-Règles importantes :
-- Signe toujours avec le nom de {user_name} (pas "Assistant IA")
-- Réponds directement aux questions posées
-- Sois concret et actionnable
-- Propose des créneaux/dates si pertinent
-- Ne mentionne jamais que tu es une IA
-- Ne mentionne JAMAIS le score CRM, le stage commercial, les notes internes, les informations de pipeline, ni aucune donnée confidentielle issue du CRM dans ta réponse."""
+        # Prompt système (US-003 : sans consigne de dissimulation IA)
+        system_prompt = build_email_system_prompt(
+            user_name, user_role, user_company, tone, length
+        )
 
         # Contexte additionnel
         additional_context = ""

--- a/src/backend/app/services/rgpd_auto.py
+++ b/src/backend/app/services/rgpd_auto.py
@@ -13,7 +13,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 
 from app.models.database import get_session_context
-from app.models.entities import Activity, Contact, Notification
+from app.models.entities import Activity, Contact, EmailMessage, Notification
 from sqlmodel import select
 
 logger = logging.getLogger(__name__)
@@ -22,23 +22,35 @@ logger = logging.getLogger(__name__)
 DEFAULT_RETENTION_MONTHS = 36
 
 
-async def purge_contact_vector(contact_id: str) -> int:
+async def purge_contact_vector(contact_id: str, max_attempts: int = 3) -> int:
     """Supprime l'embedding Qdrant d'un contact (droit à l'oubli, Art. 17).
 
     Sans cette purge, la fiche anonymisée [ANONYMISÉ] continue de remonter en
     recherche sémantique au même score (constat C4 de la revue produit) :
     l'effacement reste incomplet et la faille RGPD est démontrable.
 
-    Best effort : une panne Qdrant ne doit pas faire échouer l'anonymisation
-    déjà actée en base. On journalise et on renvoie 0 le cas échéant.
+    US-003 (RGPD-2) : on retente en cas de panne transitoire de Qdrant pour
+    réduire la fenêtre de « vecteur fantôme ». Best effort en dernier recours :
+    une panne durable ne fait pas échouer l'anonymisation déjà actée en base
+    (journalisée en ERROR pour traçabilité/alerte).
     """
-    try:
-        from app.services.qdrant import get_qdrant_service
+    last_error: Exception | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            from app.services.qdrant import get_qdrant_service
 
-        return await get_qdrant_service().async_delete_by_entity(contact_id)
-    except Exception as e:
-        logger.warning(f"RGPD: échec purge vecteur Qdrant pour {contact_id}: {e}")
-        return 0
+            return await get_qdrant_service().async_delete_by_entity(contact_id)
+        except Exception as e:  # noqa: BLE001 - on retente puis on journalise
+            last_error = e
+            logger.warning(
+                f"RGPD: échec purge vecteur Qdrant pour {contact_id} "
+                f"(tentative {attempt}/{max_attempts}): {e}"
+            )
+    logger.error(
+        f"RGPD: purge vecteur Qdrant définitivement échouée pour {contact_id} "
+        f"après {max_attempts} tentatives: {last_error}"
+    )
+    return 0
 
 
 async def _get_purge_retention_months() -> int:
@@ -186,6 +198,15 @@ async def auto_purge_expired_contacts() -> dict[str, int]:
                 contact.stage = "archive"
                 contact.extra_data = None
                 contact.updated_at = now
+
+                # RGPD-1 (US-003) : effacer aussi les emails liés (art. 17),
+                # comme l'anonymisation manuelle. Sinon le contenu des mails du
+                # contact purgé restait en base.
+                emails = await session.execute(
+                    select(EmailMessage).where(EmailMessage.contact_id == contact.id)
+                )
+                for email_msg in emails.scalars().all():
+                    await session.delete(email_msg)
 
                 # Log d'activité
                 activity = Activity(

--- a/src/backend/app/services/skills/code_executor.py
+++ b/src/backend/app/services/skills/code_executor.py
@@ -8,6 +8,8 @@ Approche code-execution : LLM -> code Python -> exécution -> fichier.
 import ast
 import asyncio
 import logging
+import multiprocessing
+import queue
 import re
 from abc import abstractmethod
 from pathlib import Path
@@ -61,6 +63,10 @@ BLOCKED_PATTERNS: list[str] = [
     r"\bdelattr\s*\(",
     r"\bbreakpoint\s*\(",
     r"\binput\s*\(",
+    # US-001 : bloquer l'introspection par dunders, qui permet l'évasion
+    # classique du namespace restreint, ex. ().__class__.__bases__[0].__subclasses__().
+    # Le code de génération de document (openpyxl/docx/pptx) n'en a aucun usage.
+    r"__\w+__",
 ]
 
 # Imports autorisés par format
@@ -665,6 +671,30 @@ def _restricted_import(format_type: str):
     return safe_import
 
 
+def _run_generation_in_subprocess(
+    code: str,
+    output_path: str,
+    title: str,
+    format_type: str,
+    nb_slides: int,
+    result_queue: Any,
+) -> None:
+    """Cible du sous-process spawn (US-001).
+
+    Exécutée dans un interpréteur frais qui n'hérite pas de la mémoire du
+    backend (token de session, clé Fernet) : une évasion éventuelle du
+    namespace restreint ne donne donc pas accès aux secrets du process
+    principal. Le résultat (ok / error) est remonté via la queue.
+    """
+    try:
+        namespace = _build_namespace(output_path, title, format_type, nb_slides)
+        compiled = compile(code, "<llm_generated>", "exec")
+        exec(compiled, namespace)  # noqa: S102
+        result_queue.put(("ok", ""))
+    except Exception as e:  # noqa: BLE001 - tout est remonté au process parent
+        result_queue.put(("error", f"{type(e).__name__}: {e}"))
+
+
 async def execute_sandboxed(
     code: str,
     output_path: str,
@@ -673,7 +703,7 @@ async def execute_sandboxed(
     nb_slides: int = 10,
 ) -> None:
     """
-    Exécute du code Python dans un namespace restreint avec timeout.
+    Exécute du code Python dans un sous-process isolé avec timeout.
 
     Args:
         code: Code Python à exécuter
@@ -694,34 +724,37 @@ async def execute_sandboxed(
     if not is_valid_imports:
         raise CodeExecutionError(f"Validation imports échouée : {import_error}")
 
-    # 3. Construire le namespace
-    namespace = _build_namespace(output_path, title, format_type, nb_slides)
+    # 3. Exécuter dans un sous-process spawn isolé (US-001).
+    # spawn => interpréteur neuf sans la mémoire du backend ; combiné au blocage
+    # des dunders, une évasion ne peut pas atteindre les secrets du process.
+    ctx = multiprocessing.get_context("spawn")
+    result_queue: Any = ctx.Queue()
+    process = ctx.Process(
+        target=_run_generation_in_subprocess,
+        args=(code, output_path, title, format_type, nb_slides, result_queue),
+        daemon=True,
+    )
 
-    # 4. Exécuter dans un thread avec timeout
-    def _execute():
+    def _run_and_wait() -> tuple[str, str]:
+        process.start()
         try:
-            compiled = compile(code, "<llm_generated>", "exec")
-            exec(compiled, namespace)  # noqa: S102
-        except Exception as e:
-            raise CodeExecutionError(
-                f"Erreur d'exécution : {type(e).__name__}: {e}"
-            ) from e
+            status, detail = result_queue.get(timeout=EXECUTION_TIMEOUT)
+        except queue.Empty:
+            status, detail = "timeout", ""
+        finally:
+            if process.is_alive():
+                process.terminate()
+            process.join(5)
+        return status, detail
 
-    try:
-        await asyncio.wait_for(
-            asyncio.to_thread(_execute),
-            timeout=EXECUTION_TIMEOUT,
-        )
-    except asyncio.TimeoutError:
+    status, detail = await asyncio.to_thread(_run_and_wait)
+
+    if status == "timeout":
         raise CodeExecutionError(
             f"Timeout : l'exécution a dépassé {EXECUTION_TIMEOUT}s"
         )
-    except CodeExecutionError:
-        raise
-    except Exception as e:
-        raise CodeExecutionError(
-            f"Erreur inattendue : {type(e).__name__}: {e}"
-        ) from e
+    if status == "error":
+        raise CodeExecutionError(f"Erreur d'exécution : {detail}")
 
 
 class CodeGenSkill(BaseSkill):

--- a/src/backend/app/services/tool_confirmations.py
+++ b/src/backend/app/services/tool_confirmations.py
@@ -1,0 +1,36 @@
+"""US-002 - Confirmation humaine avant les outils sensibles.
+
+Certains outils ont un effet de bord sortant et irréversible (envoi d'email).
+Le LLM ne doit pas pouvoir les déclencher seul : l'action est mise en attente
+ici, puis exécutée seulement après validation explicite de l'utilisateur via
+l'endpoint /api/chat/confirm-tool.
+
+Le stockage est volontairement en mémoire (durée de vie d'une confirmation =
+quelques secondes/minutes). Une confirmation perdue à un redémarrage est sans
+conséquence : l'action n'a tout simplement pas eu lieu (fail-safe).
+"""
+import uuid
+from typing import Any
+
+# Outils à effet de bord sortant/irréversible : exécution soumise à validation.
+SENSITIVE_TOOL_NAMES: set[str] = {"send_email"}
+
+# confirmation_id -> (tool_name, arguments)
+_pending: dict[str, tuple[str, dict[str, Any]]] = {}
+
+
+def requires_confirmation(tool_name: str) -> bool:
+    """True si l'outil ne doit jamais s'exécuter sans validation utilisateur."""
+    return tool_name in SENSITIVE_TOOL_NAMES
+
+
+def register_pending(tool_name: str, arguments: dict[str, Any]) -> str:
+    """Enregistre une action en attente et renvoie son identifiant."""
+    confirmation_id = uuid.uuid4().hex
+    _pending[confirmation_id] = (tool_name, dict(arguments))
+    return confirmation_id
+
+
+def pop_pending(confirmation_id: str) -> tuple[str, dict[str, Any]] | None:
+    """Retourne et consomme l'action en attente (None si inconnue/déjà consommée)."""
+    return _pending.pop(confirmation_id, None)

--- a/src/frontend/src/components/chat/ChatInput.tsx
+++ b/src/frontend/src/components/chat/ChatInput.tsx
@@ -15,6 +15,7 @@ import { SlashCommandsMenu, detectSlashCommand, type SlashCommand } from './Slas
 import { InlineDropZone, FileChip } from '../files/DropZone';
 import { useChatStore } from '../../stores/chatStore';
 import { useStatusStore } from '../../stores/statusStore';
+import { useToolConfirmationStore } from '../../stores/toolConfirmationStore';
 import { useFileDrop, type DroppedFile } from '../../hooks/useFileDrop';
 import { useVoiceRecorder } from '../../hooks/useVoiceRecorder';
 import { streamMessage, streamDeepResearch, indexFile, ApiError, getLLMConfig, setLLMConfig, type LLMProvider } from '../../services/api';
@@ -451,6 +452,10 @@ export function ChatInput({ onOpenCommandPalette, initialPrompt, initialSkillId,
           accumulatedContent += downloadMsg;
           pendingChunk += downloadMsg;
           flushToDisplay();
+        } else if (chunk.type === 'confirmation_required' && chunk.confirmation) {
+          // US-002 : action sensible (envoi d'email) en attente de validation.
+          // On affiche une carte de confirmation ; rien n'est exécuté sans clic.
+          useToolConfirmationStore.getState().add(chunk.confirmation);
         } else if (chunk.type === 'done') {
           // Store usage and uncertainty metadata (US-ESC-02, US-ESC-01)
           if (chunk.usage || chunk.uncertainty) {

--- a/src/frontend/src/components/chat/ChatLayout.tsx
+++ b/src/frontend/src/components/chat/ChatLayout.tsx
@@ -14,6 +14,7 @@ import { MessageList } from './MessageList';
 import { ChatInput } from './ChatInput';
 import { CommandPalette } from './CommandPalette';
 import { ConversationMemoryChip } from './ConversationMemoryChip';
+import { ToolConfirmationCard } from './ToolConfirmationCard';
 import { ShortcutsModal } from './ShortcutsModal';
 import { ConversationSidebar } from '../sidebar/ConversationSidebar';
 import { DropZone } from '../files/DropZone';
@@ -250,6 +251,8 @@ export function ChatLayout() {
             </div>
             {!guidedPanelActive && (
               <>
+                {/* US-002 : actions sensibles (envoi d'email) à valider */}
+                <ToolConfirmationCard />
                 {/* L6 : pastille de glance « N contacts liés à cette conversation » */}
                 <ConversationMemoryChip />
                 <div className="border-t border-border">

--- a/src/frontend/src/components/chat/ToolConfirmationCard.test.tsx
+++ b/src/frontend/src/components/chat/ToolConfirmationCard.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ToolConfirmationCard } from './ToolConfirmationCard';
+import { useToolConfirmationStore } from '../../stores/toolConfirmationStore';
+
+vi.mock('../../services/api/chat', () => ({
+  confirmTool: vi
+    .fn()
+    .mockResolvedValue({ status: 'executed', tool_name: 'send_email', result: 'Email envoyé' }),
+}));
+import { confirmTool } from '../../services/api/chat';
+
+describe('ToolConfirmationCard (US-002)', () => {
+  beforeEach(() => {
+    useToolConfirmationStore.setState({ pending: [] });
+    vi.clearAllMocks();
+  });
+
+  it("n'affiche rien sans action en attente", () => {
+    render(<ToolConfirmationCard />);
+    expect(screen.queryByTestId('tool-confirmation')).toBeNull();
+  });
+
+  it('affiche le récap et envoie après clic sur Envoyer', async () => {
+    useToolConfirmationStore.getState().add({
+      confirmation_id: 'a',
+      tool_name: 'send_email',
+      arguments: { to: 'x@y.fr', subject: 'Sujet', body: 'Corps' },
+    });
+    render(<ToolConfirmationCard />);
+
+    expect(screen.queryByText('x@y.fr')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Envoyer'));
+
+    await waitFor(() => expect(confirmTool).toHaveBeenCalledWith('a', true));
+    await waitFor(() =>
+      expect(useToolConfirmationStore.getState().pending).toHaveLength(0)
+    );
+  });
+
+  it('annule sans exécuter quand on clique Annuler', async () => {
+    useToolConfirmationStore.getState().add({
+      confirmation_id: 'b',
+      tool_name: 'send_email',
+      arguments: { to: 'z@y.fr', subject: 'S', body: 'B' },
+    });
+    render(<ToolConfirmationCard />);
+
+    fireEvent.click(screen.getByText('Annuler'));
+
+    await waitFor(() => expect(confirmTool).toHaveBeenCalledWith('b', false));
+    await waitFor(() =>
+      expect(useToolConfirmationStore.getState().pending).toHaveLength(0)
+    );
+  });
+});

--- a/src/frontend/src/components/chat/ToolConfirmationCard.tsx
+++ b/src/frontend/src/components/chat/ToolConfirmationCard.tsx
@@ -1,0 +1,106 @@
+/**
+ * THÉRÈSE v2 - ToolConfirmationCard (US-002)
+ *
+ * Affiche les actions sensibles (ex. envoi d'email) en attente de validation.
+ * Le backend ne les exécute jamais seul : l'utilisateur confirme ici, et
+ * l'exécution réelle a lieu via POST /api/chat/confirm-tool.
+ */
+import { useState } from 'react';
+import { Mail, Send, X, Loader2 } from 'lucide-react';
+import {
+  useToolConfirmationStore,
+  type PendingConfirmation,
+} from '../../stores/toolConfirmationStore';
+import { confirmTool } from '../../services/api/chat';
+import { useChatStore } from '../../stores/chatStore';
+import { Button } from '../ui/Button';
+
+export function ToolConfirmationCard() {
+  const pending = useToolConfirmationStore((s) => s.pending);
+  if (pending.length === 0) return null;
+  return (
+    <div className="space-y-2 px-4 py-2">
+      {pending.map((c) => (
+        <ConfirmationItem key={c.confirmation_id} confirmation={c} />
+      ))}
+    </div>
+  );
+}
+
+function ConfirmationItem({ confirmation }: { confirmation: PendingConfirmation }) {
+  const [busy, setBusy] = useState<'send' | 'cancel' | null>(null);
+  const remove = useToolConfirmationStore((s) => s.remove);
+  const addMessage = useChatStore((s) => s.addMessage);
+
+  const to = String(confirmation.arguments.to ?? '');
+  const subject = String(confirmation.arguments.subject ?? '');
+  const body = String(confirmation.arguments.body ?? '');
+
+  const handle = async (approved: boolean) => {
+    setBusy(approved ? 'send' : 'cancel');
+    try {
+      const res = await confirmTool(confirmation.confirmation_id, approved);
+      if (approved) {
+        addMessage({ role: 'assistant', content: res.result || 'Email envoyé.' });
+      }
+    } catch (e) {
+      addMessage({
+        role: 'assistant',
+        content: `Erreur lors de l'envoi : ${e instanceof Error ? e.message : 'inconnue'}`,
+      });
+    } finally {
+      remove(confirmation.confirmation_id);
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div
+      className="rounded-lg border border-accent-cyan/30 bg-surface p-3"
+      data-testid="tool-confirmation"
+    >
+      <div className="flex items-center gap-2 mb-2 text-accent-cyan">
+        <Mail className="w-4 h-4" />
+        <span className="text-sm font-medium text-text">Confirmer l'envoi de l'email</span>
+      </div>
+      <dl className="text-xs text-text-muted space-y-1 mb-3">
+        <div>
+          <span className="text-text-muted/70">À : </span>
+          <span className="text-text">{to}</span>
+        </div>
+        <div>
+          <span className="text-text-muted/70">Objet : </span>
+          <span className="text-text">{subject}</span>
+        </div>
+        <div className="whitespace-pre-wrap">
+          <span className="text-text-muted/70">Message : </span>
+          <span className="text-text">{body}</span>
+        </div>
+      </dl>
+      <div className="flex gap-2">
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => handle(true)}
+          disabled={busy !== null}
+        >
+          {busy === 'send' ? (
+            <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+          ) : (
+            <Send className="w-4 h-4 mr-1" />
+          )}
+          Envoyer
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => handle(false)}
+          disabled={busy !== null}
+        >
+          <X className="w-4 h-4 mr-1" />
+          Annuler
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/onboarding/SecurityStep.tsx
+++ b/src/frontend/src/components/onboarding/SecurityStep.tsx
@@ -12,6 +12,7 @@ import {
   ExternalLink,
 } from 'lucide-react';
 import { cn } from '../../lib/utils';
+import { recordCloudConsent } from '../../lib/consent';
 
 interface SecurityStepProps {
   onNext: () => void;
@@ -205,7 +206,11 @@ export function SecurityStep({ onNext, onBack }: SecurityStepProps) {
           Retour
         </button>
         <button
-          onClick={onNext}
+          onClick={() => {
+            // RGPD-4 (US-003) : tracer le consentement (horodaté) avant de continuer.
+            recordCloudConsent();
+            onNext();
+          }}
           disabled={!acknowledged}
           data-testid="onboarding-next-btn"
           className={cn(

--- a/src/frontend/src/lib/consent.test.ts
+++ b/src/frontend/src/lib/consent.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { recordCloudConsent, getCloudConsent } from './consent';
+
+// Le setup global mocke localStorage avec des vi.fn() non persistants ; on
+// installe ici un localStorage à mémoire réelle pour tester record + relecture.
+describe('consentement transfert cloud (US-003 RGPD-4)', () => {
+  beforeEach(() => {
+    const store: Record<string, string> = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+      clear: () => {
+        for (const k of Object.keys(store)) delete store[k];
+      },
+    });
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('persiste le consentement horodaté et versionné', () => {
+    recordCloudConsent('2026-06-10T10:00:00.000Z');
+    const c = getCloudConsent();
+    expect(c?.accepted).toBe(true);
+    expect(c?.timestamp).toBe('2026-06-10T10:00:00.000Z');
+    expect(c?.version).toBeTruthy();
+  });
+
+  it('retourne null tant qu’aucun consentement n’est donné', () => {
+    expect(getCloudConsent()).toBeNull();
+  });
+});

--- a/src/frontend/src/lib/consent.ts
+++ b/src/frontend/src/lib/consent.ts
@@ -1,0 +1,37 @@
+/**
+ * THÉRÈSE v2 - Consentement transfert cloud (US-003 / RGPD-4)
+ *
+ * Le consentement au transfert de données vers les providers LLM cloud, donné
+ * à l'onboarding, était un simple état React non persisté (pas de trace). On
+ * le persiste désormais, horodaté et versionné, pour la démontrabilité.
+ */
+export const CLOUD_CONSENT_KEY = 'therese-cloud-consent';
+export const CLOUD_CONSENT_VERSION = '1';
+
+export interface CloudConsentRecord {
+  accepted: boolean;
+  version: string;
+  timestamp: string;
+}
+
+export function recordCloudConsent(
+  timestamp: string = new Date().toISOString()
+): CloudConsentRecord {
+  const record: CloudConsentRecord = {
+    accepted: true,
+    version: CLOUD_CONSENT_VERSION,
+    timestamp,
+  };
+  localStorage.setItem(CLOUD_CONSENT_KEY, JSON.stringify(record));
+  return record;
+}
+
+export function getCloudConsent(): CloudConsentRecord | null {
+  const raw = localStorage.getItem(CLOUD_CONSENT_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as CloudConsentRecord;
+  } catch {
+    return null;
+  }
+}

--- a/src/frontend/src/services/api/chat.ts
+++ b/src/frontend/src/services/api/chat.ts
@@ -57,7 +57,7 @@ export interface DetectedEntities {
 }
 
 export interface StreamChunk {
-  type: 'text' | 'done' | 'error' | 'status' | 'tool_result' | 'entities_detected' | 'conversation_id' | 'sources' | 'decomposition' | 'searching' | 'search_done' | 'synthesizing' | 'skill_file';
+  type: 'text' | 'done' | 'error' | 'status' | 'tool_result' | 'entities_detected' | 'conversation_id' | 'sources' | 'decomposition' | 'searching' | 'search_done' | 'synthesizing' | 'skill_file' | 'confirmation_required';
   content: string;
   conversation_id?: string;
   message_id?: string;
@@ -70,6 +70,11 @@ export interface StreamChunk {
     file_size: number;
     download_url: string;
     format: string;
+  };
+  confirmation?: {
+    confirmation_id: string;
+    tool_name: string;
+    arguments: Record<string, unknown>;
   };
   usage?: {
     input_tokens: number;
@@ -263,5 +268,22 @@ export async function getConversationMessages(
 export async function deleteConversation(id: string): Promise<void> {
   await request<{ deleted: boolean }>(`/api/chat/conversations/${id}`, {
     method: 'DELETE',
+  });
+}
+
+export interface ConfirmToolResponse {
+  status: 'executed' | 'cancelled';
+  tool_name: string;
+  result?: string;
+}
+
+// US-002 : valide (ou annule) une action sensible mise en attente (ex. send_email).
+export async function confirmTool(
+  confirmationId: string,
+  approved: boolean
+): Promise<ConfirmToolResponse> {
+  return request<ConfirmToolResponse>('/api/chat/confirm-tool', {
+    method: 'POST',
+    body: JSON.stringify({ confirmation_id: confirmationId, approved }),
   });
 }

--- a/src/frontend/src/stores/toolConfirmationStore.test.ts
+++ b/src/frontend/src/stores/toolConfirmationStore.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useToolConfirmationStore } from './toolConfirmationStore';
+
+const conf = (id: string) => ({
+  confirmation_id: id,
+  tool_name: 'send_email',
+  arguments: { to: 'x@y.fr', subject: 'S', body: 'B' },
+});
+
+describe('toolConfirmationStore (US-002)', () => {
+  beforeEach(() => useToolConfirmationStore.setState({ pending: [] }));
+
+  it('ajoute une confirmation en attente', () => {
+    useToolConfirmationStore.getState().add(conf('a'));
+    expect(useToolConfirmationStore.getState().pending).toHaveLength(1);
+  });
+
+  it('ignore un doublon (même confirmation_id)', () => {
+    useToolConfirmationStore.getState().add(conf('a'));
+    useToolConfirmationStore.getState().add(conf('a'));
+    expect(useToolConfirmationStore.getState().pending).toHaveLength(1);
+  });
+
+  it('retire une confirmation par son id', () => {
+    useToolConfirmationStore.getState().add(conf('a'));
+    useToolConfirmationStore.getState().add(conf('b'));
+    useToolConfirmationStore.getState().remove('a');
+    const ids = useToolConfirmationStore.getState().pending.map((p) => p.confirmation_id);
+    expect(ids).toEqual(['b']);
+  });
+});

--- a/src/frontend/src/stores/toolConfirmationStore.ts
+++ b/src/frontend/src/stores/toolConfirmationStore.ts
@@ -1,0 +1,36 @@
+/**
+ * THÉRÈSE v2 - Tool Confirmation Store (US-002)
+ *
+ * Actions sensibles (ex. send_email) mises en attente par le backend : elles
+ * ne s'exécutent qu'après validation explicite de l'utilisateur via une carte
+ * de confirmation affichée dans le chat.
+ */
+import { create } from 'zustand';
+
+export interface PendingConfirmation {
+  confirmation_id: string;
+  tool_name: string;
+  arguments: Record<string, unknown>;
+}
+
+interface ToolConfirmationStore {
+  pending: PendingConfirmation[];
+  add: (confirmation: PendingConfirmation) => void;
+  remove: (confirmationId: string) => void;
+  clear: () => void;
+}
+
+export const useToolConfirmationStore = create<ToolConfirmationStore>((set) => ({
+  pending: [],
+  add: (confirmation) =>
+    set((state) =>
+      state.pending.some((p) => p.confirmation_id === confirmation.confirmation_id)
+        ? state
+        : { pending: [...state.pending, confirmation] }
+    ),
+  remove: (confirmationId) =>
+    set((state) => ({
+      pending: state.pending.filter((p) => p.confirmation_id !== confirmationId),
+    })),
+  clear: () => set({ pending: [] }),
+}));

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ Pytest fixtures and configuration for all tests.
 
 import os
 import sys
+import tempfile
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator
@@ -26,6 +27,10 @@ if _backend_dir not in sys.path:
 # Set test environment before importing app
 os.environ["THERESE_ENV"] = "test"
 os.environ["THERESE_SKIP_SERVICES"] = "1"
+# Isolation des données : ne JAMAIS toucher la base réelle de l'utilisateur.
+# Les fixtures client/db_session font drop_all/create_all ; sans data dir dédié,
+# lancer la suite détruirait ~/.therese. setdefault respecte un override (CI/dev).
+os.environ.setdefault("THERESE_DATA_DIR", tempfile.mkdtemp(prefix="therese-test-"))
 
 from app.main import app
 from app.models.database import get_session

--- a/tests/test_chat_tool_confirmation.py
+++ b/tests/test_chat_tool_confirmation.py
@@ -1,0 +1,87 @@
+"""US-002 : la boucle d'outils n'exécute jamais send_email sans confirmation.
+
+Test d'intégration de _execute_tools_and_continue : un appel send_email du LLM
+doit être mis en attente (événement confirmation_required) et NE PAS déclencher
+execute_workspace_tool.
+"""
+import json
+from unittest.mock import MagicMock
+
+import app.routers.chat as chat_mod
+import pytest
+from app.routers.chat import _execute_tools_and_continue
+from app.services import tool_confirmations
+from app.services.llm import ToolCall
+
+
+class _Event:
+    def __init__(self, type, content="", tool_call=None, stop_reason="end_turn"):
+        self.type = type
+        self.content = content
+        self.tool_call = tool_call
+        self.stop_reason = stop_reason
+
+
+class _FakeLLM:
+    async def continue_with_tool_results(
+        self, context, assistant_content, tool_calls, tool_results, tools
+    ):
+        self.received_tool_results = tool_results
+        yield _Event("done", stop_reason="end_turn")
+
+
+def _parse_chunks(raw_chunks):
+    out = []
+    for c in raw_chunks:
+        body = c[len("data: ") :].strip() if c.startswith("data: ") else c.strip()
+        try:
+            out.append(json.loads(body))
+        except json.JSONDecodeError:
+            pass
+    return out
+
+
+@pytest.mark.asyncio
+async def test_send_email_demande_confirmation_sans_envoyer(monkeypatch):
+    executed = {"workspace": False}
+
+    async def _spy_execute(*args, **kwargs):
+        executed["workspace"] = True
+        return "ENVOYÉ"
+
+    monkeypatch.setattr(chat_mod, "execute_workspace_tool", _spy_execute)
+
+    llm = _FakeLLM()
+    tc = ToolCall(
+        id="t1",
+        name="send_email",
+        arguments={"to": "x@y.fr", "subject": "Sujet", "body": "Corps"},
+    )
+
+    raw = [
+        chunk
+        async for chunk in _execute_tools_and_continue(
+            llm, None, None, "", [tc], [], "conv1", 3, session=MagicMock()
+        )
+    ]
+    chunks = _parse_chunks(raw)
+
+    # 1. send_email n'a PAS été exécuté automatiquement.
+    assert executed["workspace"] is False
+
+    # 2. Un événement de demande de confirmation a été émis avec les détails.
+    confirms = [c for c in chunks if c.get("type") == "confirmation_required"]
+    assert len(confirms) == 1
+    payload = confirms[0]["confirmation"]
+    assert payload["tool_name"] == "send_email"
+    assert payload["arguments"]["to"] == "x@y.fr"
+
+    # 3. L'action est réellement en attente et consommable une fois.
+    cid = payload["confirmation_id"]
+    assert tool_confirmations.pop_pending(cid) == (
+        "send_email",
+        {"to": "x@y.fr", "subject": "Sujet", "body": "Corps"},
+    )
+
+    # 4. Le LLM a reçu un résultat marquant l'action comme non exécutée.
+    assert any(not tr.is_error for tr in llm.received_tool_results)

--- a/tests/test_code_executor_sandbox.py
+++ b/tests/test_code_executor_sandbox.py
@@ -1,0 +1,111 @@
+"""US-001 : durcissement du sandbox d'exécution de code (skills Office).
+
+Deux protections :
+1. Blocage de l'introspection par dunders (évasion classique du namespace
+   restreint : ().__class__.__bases__[0].__subclasses__()).
+2. Exécution dans un sous-process spawn isolé : l'interpréteur enfant n'hérite
+   pas de la mémoire du backend (token de session, clé Fernet), donc une
+   éventuelle évasion ne donne pas accès aux secrets du process principal.
+"""
+import queue
+
+import pytest
+
+from app.services.skills.code_executor import (
+    CodeExecutionError,
+    _run_generation_in_subprocess,
+    execute_sandboxed,
+    validate_code,
+)
+
+XLSX_OK = "wb = Workbook()\nws = wb.active\nws['A1'] = title\nwb.save(output_path)"
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        "x = ().__class__.__bases__",
+        "x = ().__class__.__subclasses__()",
+        "x = type.__mro__",
+        "x = (1).__class__.__globals__",
+        "x = ().__class__.__base__.__subclasses__()",
+    ],
+)
+def test_validate_code_bloque_introspection_dunder(snippet):
+    is_valid, _ = validate_code(snippet)
+    assert is_valid is False
+
+
+def test_validate_code_accepte_du_code_office_legitime():
+    is_valid, msg = validate_code(XLSX_OK)
+    assert is_valid is True, msg
+
+
+def test_worker_genere_le_fichier_et_signale_ok(tmp_path):
+    out = tmp_path / "test.xlsx"
+    rq: queue.Queue = queue.Queue()
+    _run_generation_in_subprocess(XLSX_OK, str(out), "Mon titre", "xlsx", 10, rq)
+    status, _ = rq.get_nowait()
+    assert status == "ok"
+    assert out.exists()
+
+
+def test_worker_signale_erreur_sur_code_qui_leve(tmp_path):
+    rq: queue.Queue = queue.Queue()
+    _run_generation_in_subprocess(
+        "raise ValueError('boum')", str(tmp_path / "x.xlsx"), "T", "xlsx", 10, rq
+    )
+    status, detail = rq.get_nowait()
+    assert status == "error"
+    assert "boum" in detail
+
+
+@pytest.mark.asyncio
+async def test_execute_sandboxed_rejette_evasion_dunder(tmp_path):
+    code = "wb = Workbook()\nx = ().__class__.__bases__\nwb.save(output_path)"
+    with pytest.raises(CodeExecutionError):
+        await execute_sandboxed(code, str(tmp_path / "x.xlsx"), "T", "xlsx")
+
+
+@pytest.mark.asyncio
+async def test_execute_sandboxed_passe_par_un_sous_process_spawn(monkeypatch, tmp_path):
+    """L'exécution doit transiter par un Process spawn isolé, pas par le thread
+    du backend (sinon une évasion accéderait aux secrets en mémoire)."""
+    import multiprocessing as mp
+
+    captured: dict = {}
+    real_get_context = mp.get_context
+
+    class _Q:
+        def get(self, timeout=None):
+            return ("ok", "")
+
+    class _P:
+        def __init__(self, target, args, daemon=False):
+            captured["target"] = target
+
+        def start(self):
+            pass
+
+        def is_alive(self):
+            return False
+
+        def join(self, t=None):
+            pass
+
+        def terminate(self):
+            pass
+
+    class _Ctx:
+        def Queue(self):
+            return _Q()
+
+        def Process(self, target, args, daemon=False):
+            return _P(target, args, daemon)
+
+    monkeypatch.setattr(
+        mp, "get_context", lambda m: _Ctx() if m == "spawn" else real_get_context(m)
+    )
+
+    await execute_sandboxed(XLSX_OK, str(tmp_path / "x.xlsx"), "T", "xlsx")
+    assert captured["target"].__name__ == "_run_generation_in_subprocess"

--- a/tests/test_confirm_tool_endpoint.py
+++ b/tests/test_confirm_tool_endpoint.py
@@ -1,0 +1,59 @@
+"""US-002 : endpoint de confirmation d'une action sensible.
+
+POST /api/chat/confirm-tool exécute (ou annule) une action send_email mise en
+attente par la boucle d'outils, après validation explicite de l'utilisateur.
+"""
+import app.routers.chat as chat_mod
+import pytest
+from app.services.tool_confirmations import register_pending
+
+
+@pytest.mark.asyncio
+async def test_confirm_tool_execute_apres_validation(client, monkeypatch):
+    captured: dict = {}
+
+    async def _spy(tool_name, arguments, session):
+        captured["tool"] = tool_name
+        captured["args"] = arguments
+        return "Email envoyé à x@y.fr"
+
+    monkeypatch.setattr(chat_mod, "execute_workspace_tool", _spy)
+
+    cid = register_pending("send_email", {"to": "x@y.fr", "subject": "S", "body": "B"})
+    resp = await client.post(
+        "/api/chat/confirm-tool", json={"confirmation_id": cid, "approved": True}
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "executed"
+    assert "envoyé" in data["result"].lower()
+    assert captured["tool"] == "send_email"
+
+
+@pytest.mark.asyncio
+async def test_confirm_tool_annulation_n_execute_pas(client, monkeypatch):
+    called = {"executed": False}
+
+    async def _spy(*args, **kwargs):
+        called["executed"] = True
+        return "?"
+
+    monkeypatch.setattr(chat_mod, "execute_workspace_tool", _spy)
+
+    cid = register_pending("send_email", {"to": "x@y.fr"})
+    resp = await client.post(
+        "/api/chat/confirm-tool", json={"confirmation_id": cid, "approved": False}
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "cancelled"
+    assert called["executed"] is False
+
+
+@pytest.mark.asyncio
+async def test_confirm_tool_id_inconnu_renvoie_404(client):
+    resp = await client.post(
+        "/api/chat/confirm-tool", json={"confirmation_id": "inconnu", "approved": True}
+    )
+    assert resp.status_code == 404

--- a/tests/test_data_isolation.py
+++ b/tests/test_data_isolation.py
@@ -1,0 +1,18 @@
+"""Garde-fou : la suite de tests ne doit JAMAIS s'exécuter contre la base
+réelle de l'utilisateur (~/.therese). Les fixtures `client`/`db_session` font
+un drop_all/create_all : sans data dir isolé, lancer les tests détruit les
+données locales. Le conftest doit forcer THERESE_DATA_DIR.
+
+Ce test n'utilise volontairement aucune fixture DB (pas de drop_all)."""
+from pathlib import Path
+
+from app.config import settings
+
+
+def test_les_tests_n_utilisent_pas_la_base_reelle():
+    real = Path.home() / ".therese"
+    assert settings.data_dir is not None
+    assert Path(settings.data_dir).resolve() != real.resolve(), (
+        "Les tests pointent sur la base réelle ~/.therese ; le conftest doit "
+        "définir THERESE_DATA_DIR vers un dossier temporaire."
+    )

--- a/tests/test_email_response_prompt.py
+++ b/tests/test_email_response_prompt.py
@@ -1,0 +1,21 @@
+"""US-003 (RGPD-3 / IA Act art. 50) : le générateur de réponses email ne doit
+plus instruire l'IA de dissimuler sa nature. La signature au nom de
+l'utilisateur reste, mais la consigne « ne mentionne jamais que tu es une IA »
+est retirée (indéfendable, et risquée si un envoi automatique apparaissait)."""
+from app.services.email_response_generator import build_email_system_prompt
+
+
+def test_prompt_ne_dissimule_pas_l_ia():
+    prompt = build_email_system_prompt("Ludo", "Consultant IA", "Synoptïa")
+    assert "Ne mentionne jamais que tu es une IA" not in prompt
+    assert "tu es une IA" not in prompt
+
+
+def test_prompt_conserve_la_signature_au_nom_de_l_utilisateur():
+    prompt = build_email_system_prompt("Ludo", "Consultant IA", "Synoptïa")
+    assert "Signe toujours avec le nom de Ludo" in prompt
+
+
+def test_prompt_protege_toujours_les_donnees_crm():
+    prompt = build_email_system_prompt("Ludo", "Consultant IA", "Synoptïa")
+    assert "score CRM" in prompt

--- a/tests/test_rgpd_erasure.py
+++ b/tests/test_rgpd_erasure.py
@@ -1,0 +1,64 @@
+"""US-003 (RGPD-1) : l'anonymisation d'un contact (droit à l'oubli, art. 17)
+doit aussi effacer ses emails liés. Ils restaient en base avec le contact_id,
+contenu intégral inclus — effacement incomplet."""
+from datetime import UTC, datetime
+
+import pytest
+from app.models.entities import Contact, EmailAccount, EmailMessage
+from sqlmodel import select
+
+
+@pytest.mark.asyncio
+async def test_anonymisation_efface_les_emails_du_contact(client, db_session):
+    db_session.add(EmailAccount(id="acc1", email="me@x.fr", provider="gmail"))
+    db_session.add(Contact(id="c1", first_name="Jean", last_name="Test", email="jean@x.fr"))
+    db_session.add(
+        EmailMessage(
+            id="m1",
+            thread_id="t1",
+            account_id="acc1",
+            from_email="jean@x.fr",
+            to_emails='["me@x.fr"]',
+            date=datetime.now(UTC),
+            internal_date=datetime.now(UTC),
+            labels='["INBOX"]',
+            contact_id="c1",
+            subject="Confidentiel",
+            body_plain="contenu personnel à effacer",
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.post("/api/rgpd/anonymize/c1", json={"reason": "demande client"})
+    assert resp.status_code == 200
+
+    remaining = (
+        await db_session.execute(
+            select(EmailMessage).where(EmailMessage.contact_id == "c1")
+        )
+    ).scalars().all()
+    assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_purge_vecteur_retente_apres_echec_transitoire(monkeypatch):
+    """RGPD-2 : une panne transitoire de Qdrant ne doit pas laisser un vecteur
+    fantôme (recherche sémantique). On retente avant d'abandonner."""
+    from app.services import rgpd_auto
+
+    calls = {"n": 0}
+
+    class _FlakyQdrant:
+        async def async_delete_by_entity(self, _cid):
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise RuntimeError("Qdrant momentanément indisponible")
+            return 1
+
+    monkeypatch.setattr(
+        "app.services.qdrant.get_qdrant_service", lambda: _FlakyQdrant()
+    )
+
+    purged = await rgpd_auto.purge_contact_vector("c1")
+    assert purged == 1
+    assert calls["n"] == 2

--- a/tests/test_routers_dashboard.py
+++ b/tests/test_routers_dashboard.py
@@ -1,8 +1,32 @@
 """Tests du router dashboard (setup-status pour la vue Accueil)."""
 import pytest
+from app.models.entities import Calendar, Contact, EmailAccount
 from httpx import AsyncClient
 
-from app.models.entities import Calendar, EmailAccount
+
+class TestToday:
+    @pytest.mark.asyncio
+    async def test_today_stale_prospect_remonte_avec_son_nom(
+        self, client: AsyncClient, db_session
+    ):
+        """Régression : un prospect sans interaction doit apparaître dans
+        stale_prospects avec son nom. Contact n'a pas d'attribut `name`
+        (lève AttributeError, avalé en liste vide) — il faut display_name."""
+        db_session.add(
+            Contact(
+                id="ct-stale-1",
+                first_name="Jean",
+                last_name="Test",
+                stage="contact",
+                last_interaction=None,
+            )
+        )
+        await db_session.commit()
+
+        resp = await client.get("/api/dashboard/today")
+        assert resp.status_code == 200
+        prospects = resp.json()["stale_prospects"]
+        assert [p["name"] for p in prospects] == ["Jean Test"]
 
 
 class TestSetupStatus:

--- a/tests/test_shutdown_exempt.py
+++ b/tests/test_shutdown_exempt.py
@@ -1,0 +1,38 @@
+"""US-005 : /api/shutdown doit être exempté de l'auth middleware.
+
+En production, le token de session est défini. Sans exemption, l'appel de
+Tauri (TcpStream à la fermeture) et d'UpdateBanner, qui n'envoient pas le
+token, repart en 401 : le shutdown graceful n'a jamais lieu (force-kill, et
+verrou backend.exe pendant l'auto-update Windows, BUG-099).
+
+NB : le lifespan de test ne génère pas de session_token, donc l'auth est
+inopérante par défaut en test. On force un token pour activer le middleware.
+"""
+import os
+
+import pytest
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_shutdown_exempte_du_token_de_session(client, monkeypatch):
+    # Le handler programme un os.kill différé : on le neutralise pour le test.
+    monkeypatch.setattr(os, "kill", lambda *a, **k: None)
+    # Activer l'auth middleware (absent en test) avec un token de session.
+    monkeypatch.setattr(app.state, "session_token", "tok-test", raising=False)
+
+    # Aucun header X-Therese-Token : doit passer (exempté), pas 401.
+    resp = await client.post("/api/shutdown")
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "shutting_down"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_protege_reste_401_sans_token(client, monkeypatch):
+    """Garde-fou : l'exemption du shutdown ne désactive pas l'auth globale."""
+    monkeypatch.setattr(app.state, "session_token", "tok-test", raising=False)
+
+    resp = await client.get("/api/notifications/count")
+
+    assert resp.status_code == 401

--- a/tests/test_tool_confirmations.py
+++ b/tests/test_tool_confirmations.py
@@ -1,0 +1,35 @@
+"""US-002 : confirmation humaine avant les outils sensibles (ex. send_email).
+
+Le LLM ne doit pas pouvoir déclencher seul un envoi de mail : l'action est
+mise en attente et n'est exécutée qu'après validation explicite de l'utilisateur.
+"""
+from app.services.tool_confirmations import (
+    pop_pending,
+    register_pending,
+    requires_confirmation,
+)
+
+
+def test_send_email_requiert_une_confirmation():
+    assert requires_confirmation("send_email") is True
+
+
+def test_outils_en_lecture_seule_ne_requierent_pas_de_confirmation():
+    assert requires_confirmation("read_emails") is False
+    assert requires_confirmation("generate_document") is False
+    assert requires_confirmation("search_emails") is False
+
+
+def test_register_puis_pop_rend_l_action_une_seule_fois():
+    cid = register_pending("send_email", {"to": "x@y.fr", "subject": "S", "body": "B"})
+    assert isinstance(cid, str) and cid
+
+    action = pop_pending(cid)
+    assert action == ("send_email", {"to": "x@y.fr", "subject": "S", "body": "B"})
+
+    # Consommée : un second pop ne rejoue pas l'action (anti-double envoi).
+    assert pop_pending(cid) is None
+
+
+def test_pop_d_un_id_inconnu_retourne_none():
+    assert pop_pending("inconnu-xyz") is None


### PR DESCRIPTION
Remédiation des P0 issus de l'audit UltraJury du 09/06/2026 (`docs/audit/ultrajury-2026-06-09.md`). Chaque lot en TDD, suites backend (RC=0) et frontend (183 verts), ruff/eslint/tsc/build OK.

## Lots (8 commits)

| Lot | Contenu |
|---|---|
| **US-001** sécurité | `exec()` du code généré par le LLM (skills Office) sorti du process backend → **sous-process `spawn` isolé** (secrets en mémoire hors d'atteinte) + blocage de l'introspection par dunders |
| **US-002** sécurité | `send_email` ne part **plus jamais sans validation** : interception dans la boucle d'outils + `POST /api/chat/confirm-tool` + carte de confirmation dans le chat |
| **US-003** RGPD/IA Act | emails du contact effacés à l'anonymisation (manuelle + auto, art. 17), purge Qdrant avec retry, retrait de la consigne « ne mentionne jamais que tu es une IA », consentement onboarding persisté + horodaté |
| **US-004** | README véridique (version 0.21, claim chiffrement honnête, lien OpenClaw réparé) |
| **US-005** | `/api/shutdown` exempté de l'auth → graceful shutdown rétabli (et update Windows débloqué) |
| **fix dashboard** | carte « prospects » de l'Accueil ne plante plus (`Contact.display_name`) |
| **fix conftest** | la suite de tests ne détruit plus la base réelle `~/.therese` (data dir temporaire forcé) |

## Dette tracée

US-001 : le sous-process `spawn` ré-importe `app.services` (torch) à chaque génération de document ; sera éliminé par US-016 (import paresseux).

## Note

CSRF `/api/shutdown` : risque accepté et documenté (ferme l'app, récupérable ; atténué par Private Network Access navigateur).

Generated with Claude Code (https://claude.com/claude-code)
