### PR TITLE
Fixes testeurs 12/06 : Mistral lecture mails (BUG-108), 403 calendrier (BUG-109), historique chat (BUG-107)

### DIFF
--- a/src/backend/app/routers/calendar.py
+++ b/src/backend/app/routers/calendar.py
@@ -158,10 +158,11 @@ def _raise_if_google_403(e: Exception) -> None:
         raise HTTPException(
             status_code=403,
             detail=(
-                "Google refuse l'accès au calendrier (403). Vérifie que l'API "
-                "« Google Calendar » est activée dans ta console Google Cloud "
+                "Google refuse l'accès au calendrier (403). Active l'API "
+                "« Google Calendar » dans ta console Google Cloud "
                 "(APIs et services > Bibliothèque > Google Calendar API > Activer), "
-                "puis reconnecte ton compte Google dans Paramètres > Services."
+                "puis relance la synchronisation. Si le souci persiste, vérifie "
+                "que l'accès au calendrier a bien été autorisé pour ce compte."
             ),
         ) from e
 

--- a/src/backend/app/services/providers/base.py
+++ b/src/backend/app/services/providers/base.py
@@ -163,7 +163,16 @@ class BaseProvider(ABC):
         """
         messages.append({
             "role": "assistant",
-            "content": assistant_content or None,
+            # BUG-108 (lcjp, 12/06/2026) : Mistral rejette en 400 un message
+            # assistant ayant à la fois un content NON vide ET des tool_calls
+            # (le modèle écrivait du texte avant l'appel d'outil → 400 → résultat
+            # read_emails perdu → boucle « Max tool iterations »). Un message
+            # porteur de tool_calls ne transporte donc jamais de texte : on force
+            # `None` (valeur canonique OpenAI/litellm pour un message tool-call,
+            # déjà envoyée par l'ancien code quand le texte était vide, donc
+            # éprouvée côté Mistral). Le texte pré-appel reste affiché/streamé à
+            # l'utilisateur. Couvre aussi OpenRouter/Infomaniak routant vers Mistral.
+            "content": None,
             "tool_calls": [
                 {
                     "id": tc.id,

--- a/src/frontend/src/components/calendar/CalendarPanel.tsx
+++ b/src/frontend/src/components/calendar/CalendarPanel.tsx
@@ -25,6 +25,7 @@ import { useEmailStore } from '../../stores/emailStore';
 import { CalendarView } from './CalendarView';
 import { EventForm } from './EventForm';
 import { EventDetail } from './EventDetail';
+import { classifyCalendarError } from './calendarErrors';
 import { Button } from '../ui/Button';
 import * as api from '../../services/api';
 import { useStatusStore } from '../../stores/statusStore';
@@ -124,12 +125,9 @@ export function CalendarPanel({ isOpen, onClose, standalone = false }: CalendarP
     } catch (err: any) {
       console.error('Failed to load calendars:', err);
       const msg = err?.message || '';
-      if (msg.includes('expired') || msg.includes('revoked') || msg.includes('401') || msg.includes('reconnect')) {
-        setError('Connexion Google expirée.');
-        setNeedsReauth(true);
-      } else {
-        setError('Impossible de charger les calendriers');
-      }
+      const action = classifyCalendarError(msg, { fallback: 'Impossible de charger les calendriers' });
+      if (action.error !== null) setError(action.error);
+      if (action.needsReauth !== undefined) setNeedsReauth(action.needsReauth);
       // Si on a du cache, laisser les events se charger quand même
       if (hasCachedCalendars) setCalendarsReady(true);
     } finally {
@@ -157,13 +155,12 @@ export function CalendarPanel({ isOpen, onClose, standalone = false }: CalendarP
     } catch (err: any) {
       console.error('Failed to load events:', err);
       const msg = err?.message || '';
-      if (msg.includes('expired') || msg.includes('revoked') || msg.includes('401') || msg.includes('reconnect')) {
-        setError('Connexion Google expirée.');
-        setNeedsReauth(true);
-      } else if (!hasCachedEvents) {
-        // Afficher l'erreur uniquement si pas de cache
-        setError('Impossible de charger les événements');
-      }
+      const action = classifyCalendarError(msg, {
+        fallback: 'Impossible de charger les événements',
+        hasCache: hasCachedEvents,
+      });
+      if (action.error !== null) setError(action.error);
+      if (action.needsReauth !== undefined) setNeedsReauth(action.needsReauth);
     }
   }
 
@@ -188,12 +185,9 @@ export function CalendarPanel({ isOpen, onClose, standalone = false }: CalendarP
     } catch (err: any) {
       console.error('Failed to sync calendar:', err);
       const msg = err?.message || '';
-      if (msg.includes('expired') || msg.includes('revoked') || msg.includes('401') || msg.includes('reconnect')) {
-        setError('Connexion Google expirée.');
-        setNeedsReauth(true);
-      } else {
-        setError('Échec de la synchronisation');
-      }
+      const action = classifyCalendarError(msg, { fallback: 'Échec de la synchronisation' });
+      if (action.error !== null) setError(action.error);
+      if (action.needsReauth !== undefined) setNeedsReauth(action.needsReauth);
     } finally {
       setSyncing(false);
     }

--- a/src/frontend/src/components/calendar/calendarErrors.test.ts
+++ b/src/frontend/src/components/calendar/calendarErrors.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { isGoogleAuthError, classifyCalendarError } from './calendarErrors';
+
+const MSG_403 =
+  "Google refuse l'accès au calendrier (403). Active l'API « Google Calendar » dans ta " +
+  'console Google Cloud (APIs et services > Bibliothèque > Google Calendar API > Activer), ' +
+  "puis relance la synchronisation. Si le souci persiste, vérifie que l'accès au calendrier " +
+  'a bien été autorisé pour ce compte.';
+
+describe('isGoogleAuthError (BUG-109 / boucle "connexion expirée", lcjp 12/06/2026)', () => {
+  it('classe une vraie expiration / credentials manquants comme reauth (cas légitime backend 401)', () => {
+    // Message réel levé par ensure_valid_access_token (email.py) quand le refresh échoue
+    expect(isGoogleAuthError('OAuth credentials not found. Please reconnect your account.')).toBe(true);
+    expect(isGoogleAuthError('token expired')).toBe(true);
+    expect(isGoogleAuthError('refresh token revoked')).toBe(true);
+    expect(isGoogleAuthError('Unauthorized (401)')).toBe(true);
+  });
+
+  it('NE classe PAS un 403 calendrier comme expiration (sinon bannière trompeuse + boucle infinie)', () => {
+    const msg403 =
+      "Google refuse l'accès au calendrier (403). Active l'API « Google Calendar » dans ta " +
+      'console Google Cloud (APIs et services > Bibliothèque > Google Calendar API > Activer), ' +
+      "puis relance la synchronisation. Si le souci persiste, vérifie que l'accès au calendrier " +
+      'a bien été autorisé pour ce compte.';
+    expect(isGoogleAuthError(msg403)).toBe(false);
+  });
+
+  it('ignore les erreurs génériques et les valeurs vides', () => {
+    expect(isGoogleAuthError('Impossible de charger les calendriers')).toBe(false);
+    expect(isGoogleAuthError('')).toBe(false);
+    expect(isGoogleAuthError(null)).toBe(false);
+    expect(isGoogleAuthError(undefined)).toBe(false);
+  });
+});
+
+describe('classifyCalendarError', () => {
+  it('arme la reconnexion sur une vraie expiration', () => {
+    expect(classifyCalendarError('Please reconnect your account.', { fallback: 'X' })).toEqual({
+      error: 'Connexion Google expirée.',
+      needsReauth: true,
+    });
+  });
+
+  it('DÉSARME la reconnexion sur un 403 calendrier et affiche le message actionnable (BUG-109)', () => {
+    // Le point clé du must-fix : needsReauth doit repasser à false, sinon la
+    // bannière jaune (état partagé avec l'email) masque le message et boucle.
+    const action = classifyCalendarError(MSG_403, { fallback: 'X' });
+    expect(action.error).toBe(MSG_403);
+    expect(action.needsReauth).toBe(false);
+  });
+
+  it('ne touche PAS à needsReauth sur une erreur générique', () => {
+    expect(classifyCalendarError('boom réseau', { fallback: 'Échec de la synchronisation' })).toEqual({
+      error: 'Échec de la synchronisation',
+    });
+  });
+
+  it("n'affiche rien sur erreur générique si du cache est disponible", () => {
+    expect(classifyCalendarError('boom', { fallback: 'X', hasCache: true })).toEqual({ error: null });
+  });
+});

--- a/src/frontend/src/components/calendar/calendarErrors.ts
+++ b/src/frontend/src/components/calendar/calendarErrors.ts
@@ -1,0 +1,66 @@
+/**
+ * Classification des erreurs d'API calendrier Google.
+ *
+ * BUG-109 / boucle « connexion expirée » (lcjp 12/06/2026) :
+ * un 403 Google (API Calendar non activée dans le projet GCP) NE doit PAS être
+ * traité comme une expiration de jeton. Sinon le CalendarPanel affiche la
+ * bannière jaune « Connexion Google expirée », masque le message actionnable,
+ * et chaque clic sur « Reconnecter » relance un OAuth qui réussit mais ne
+ * corrige pas le 403 → boucle de reconnexion infinie.
+ *
+ * On garde la détection du radical « reconnect » car le vrai message backend
+ * d'expiration ("OAuth credentials not found. Please reconnect your account.")
+ * en dépend, mais on exclut explicitement les messages d'accès calendrier.
+ */
+export function isGoogleAuthError(message: string | null | undefined): boolean {
+  const msg = (message || '').toLowerCase();
+  // Un 403 d'accès calendrier (API non activée / accès non autorisé) n'est pas
+  // une expiration de jeton : ne jamais déclencher la reconnexion sur ce cas.
+  if (msg.includes('google calendar')) return false;
+  return (
+    msg.includes('expired') ||
+    msg.includes('revoked') ||
+    msg.includes('401') ||
+    msg.includes('reconnect')
+  );
+}
+
+export interface CalendarErrorAction {
+  /** Message à afficher, ou `null` pour ne rien afficher (cache disponible). */
+  error: string | null;
+  /**
+   * Nouvelle valeur de `needsReauth` à appliquer, ou `undefined` pour ne PAS y
+   * toucher (préserver l'état courant sur une erreur générique).
+   */
+  needsReauth?: boolean;
+}
+
+/**
+ * Décide quoi afficher pour une erreur d'API calendrier Google.
+ *
+ * Cas couverts :
+ * - vraie expiration de jeton (401/expired/revoked/reconnect) → bannière de
+ *   reconnexion (needsReauth=true) ;
+ * - 403 d'accès calendrier (API non activée) → message actionnable ET on
+ *   DÉSARME la bannière (needsReauth=false). Crucial (BUG-109 / lcjp) : un 403
+ *   prouve que le jeton est valide (sinon ce serait un 401). Comme `needsReauth`
+ *   est partagé avec l'email, une expiration Gmail antérieure peut l'avoir armé ;
+ *   sans ce reset, la bannière jaune resterait, masquerait le message actionnable
+ *   (rendu derrière `error && !needsReauth`) et entretiendrait la boucle de
+ *   reconnexion ;
+ * - autre erreur → message générique (ou `null` si du cache est disponible),
+ *   sans toucher à `needsReauth`.
+ */
+export function classifyCalendarError(
+  message: string | null | undefined,
+  opts: { fallback: string; hasCache?: boolean },
+): CalendarErrorAction {
+  const msg = message || '';
+  if (isGoogleAuthError(msg)) {
+    return { error: 'Connexion Google expirée.', needsReauth: true };
+  }
+  if (msg.includes('Google Calendar')) {
+    return { error: msg, needsReauth: false };
+  }
+  return { error: opts.hasCache ? null : opts.fallback };
+}

--- a/src/frontend/src/components/sidebar/ConversationSidebar.tsx
+++ b/src/frontend/src/components/sidebar/ConversationSidebar.tsx
@@ -60,6 +60,16 @@ export function ConversationSidebar({ isOpen, onClose }: ConversationSidebarProp
       loadConversation(id);
       onClose();
 
+      // BUG-107 : ne charger depuis le backend QUE si la conversation est
+      // synchronisée et vide localement (même garde que useConversationSync).
+      // Une conversation locale-only (ex: résultat d'un agent de préparation de
+      // RDV) n'existe pas côté backend : l'interroger renverrait [] (HTTP 200)
+      // et écraserait ses messages → disparition de l'historique.
+      const localConv = useChatStore.getState().conversations.find((c) => c.id === id);
+      if (!localConv?.synced || localConv.messages.length > 0) {
+        return;
+      }
+
       // Load messages from backend
       try {
         const messages = await api.getConversationMessages(id);

--- a/src/frontend/src/stores/chatStore.test.ts
+++ b/src/frontend/src/stores/chatStore.test.ts
@@ -175,4 +175,46 @@ describe('chatStore', () => {
       expect(useChatStore.getState().isStreaming).toBe(false);
     });
   });
+
+  // BUG-107 (régression historique chat, Capov 12/06/2026) : une conversation
+  // créée par un agent (préparation de RDV) est locale et NON synchronisée.
+  // Cliquer dessus dans la sidebar interroge le backend avec un ID inconnu, qui
+  // renvoie [] (HTTP 200) ; setConversationMessages écrasait alors ses messages
+  // et la marquait synced:true → la conversation "disparaissait de l'historique".
+  describe('setConversationMessages - BUG-107 régression historique', () => {
+    it("ne vide PAS une conversation locale non synchronisée si le backend renvoie []", () => {
+      // Conversation créée par un agent : locale, non synced, 1 message
+      useChatStore.getState().addMessage({
+        role: 'assistant',
+        content: 'Voici ta préparation de RDV.',
+      });
+      const convId = useChatStore.getState().currentConversationId!;
+      expect(useChatStore.getState().conversations[0].messages).toHaveLength(1);
+      expect(useChatStore.getState().conversations[0].synced).toBeFalsy();
+
+      // Le clic sidebar interroge le backend → [] pour un ID local inconnu
+      useChatStore.getState().setConversationMessages(convId, []);
+
+      const conv = useChatStore.getState().conversations.find((c) => c.id === convId)!;
+      // Le message de l'agent est préservé (sinon il disparaît de l'historique)
+      expect(conv.messages).toHaveLength(1);
+      expect(conv.messages[0].content).toBe('Voici ta préparation de RDV.');
+      // Et la conversation n'est pas marquée synchronisée à tort
+      expect(conv.synced).toBeFalsy();
+    });
+
+    it('remplace bien les messages quand le backend renvoie du contenu', () => {
+      useChatStore.getState().addMessage({ role: 'user', content: 'question' });
+      const convId = useChatStore.getState().currentConversationId!;
+
+      useChatStore.getState().setConversationMessages(convId, [
+        { id: 'm1', role: 'user', content: 'question', timestamp: new Date() },
+        { id: 'm2', role: 'assistant', content: 'réponse', timestamp: new Date() },
+      ]);
+
+      const conv = useChatStore.getState().conversations.find((c) => c.id === convId)!;
+      expect(conv.messages).toHaveLength(2);
+      expect(conv.synced).toBe(true);
+    });
+  });
 });

--- a/src/frontend/src/stores/chatStore.ts
+++ b/src/frontend/src/stores/chatStore.ts
@@ -307,6 +307,14 @@ export const useChatStore = create<ChatStore>()(
           const existingConv = state.conversations.find((c) => c.id === conversationId);
 
           if (existingConv) {
+            // BUG-107 (Capov 12/06/2026) : ne pas écraser une conversation locale
+            // NON synchronisée (ex: résultat d'un agent de préparation de RDV) avec
+            // une liste vide. Le backend renvoie [] (HTTP 200) pour un ID local
+            // qu'il ne connaît pas ; écraser ici effacerait le message ET marquerait
+            // synced:true → la conversation disparaîtrait de l'historique.
+            if (messages.length === 0 && !existingConv.synced) {
+              return state;
+            }
             // Update existing conversation
             return {
               conversations: state.conversations.map((c) =>

--- a/tests/test_provider_tools.py
+++ b/tests/test_provider_tools.py
@@ -836,3 +836,97 @@ async def test_anthropic_prior_turns_rejoues_dans_l_ordre():
     assert len(tool_uses) == 2 and len(tool_results_msgs) == 2
     assert tool_results_msgs[0]["content"][0]["tool_use_id"] == "call_1"
     assert tool_results_msgs[1]["content"][0]["tool_use_id"] == "call_2"
+
+
+# ---------------------------------------------------------------------------
+# Mistral (bug lcjp 12/06/2026, BUG-108) : Mistral refuse en 400 un message
+# assistant ayant à la fois un `content` NON vide ET des `tool_calls`. Quand le
+# modèle écrit du texte avant d'appeler l'outil, `_append_openai_tool_turn`
+# posait ce texte dans le message porteur des tool_calls → 400 → résultat
+# `read_emails` perdu → boucle « Max tool iterations » → fausse erreur d'auth.
+# Le helper doit donc poser un content vide sur TOUT message à tool_calls, pour
+# le tour courant ET les tours rejoués (prior_turns).
+# ---------------------------------------------------------------------------
+
+
+def _mistral(client):
+    from app.services.providers.mistral import MistralProvider
+
+    return MistralProvider(
+        LLMConfig(provider=LLMProvider.MISTRAL, model="mistral-large-latest", api_key="x"),
+        client=client,
+    )
+
+
+class _MistralStrictClient(_FakeClient):
+    """Rejoue un 400 si un message assistant porte un content non vide + tool_calls
+    (contrat réel de l'API Mistral)."""
+
+    def stream(self, method, url, **kwargs):
+        import copy
+
+        captured = {k: copy.deepcopy(v) if k == "json" else v for k, v in kwargs.items()}
+        self.requests.append({"method": method, "url": url, **captured})
+        msgs = (kwargs.get("json") or {}).get("messages", [])
+        bad = any(
+            m.get("role") == "assistant"
+            and m.get("tool_calls")
+            and (m.get("content") or "").strip()
+            for m in msgs
+        )
+        idx = min(self._call_index, len(self._responses) - 1)
+        self._call_index += 1
+        resp = (
+            _FakeStreamResponse([], status=400, body=b'{"message":"content+tool_calls"}')
+            if bad
+            else self._responses[idx]
+        )
+
+        class _CM:
+            async def __aenter__(_s):
+                return resp
+
+            async def __aexit__(_s, *a):
+                return False
+
+        return _CM()
+
+
+@pytest.mark.asyncio
+async def test_mistral_tool_turn_content_vide_pas_de_400_bug108():
+    from app.services.providers.base import ToolTurn
+
+    text_chunk = {"choices": [{"delta": {"content": "Voici tes 3 emails."}, "finish_reason": "stop"}]}
+    client = _MistralStrictClient([f"data: {json.dumps(text_chunk)}", "data: [DONE]"])
+
+    events = await _collect(
+        _mistral(client).continue_with_tool_results(
+            None,
+            [{"role": "user", "content": "lis mes emails"}],
+            # NON vide : c'est ce texte pré-appel qui déclenchait le 400 Mistral
+            assistant_content="Je vais lire tes emails.",
+            tool_calls=[ToolCall(id="call_2", name="read_emails", arguments={})],
+            tool_results=[ToolResult(tool_call_id="call_2", result="3 emails")],
+            tools=OPENAI_TOOLS,
+            prior_turns=[
+                ToolTurn(
+                    assistant_content="Laisse-moi chercher.",  # NON vide aussi
+                    tool_calls=[ToolCall(id="call_1", name="search_emails", arguments={})],
+                    tool_results=[ToolResult(tool_call_id="call_1", result="5 emails")],
+                )
+            ],
+        )
+    )
+
+    # Le 400 n'a PAS été déclenché : aucun event d'erreur, la réponse finale arrive
+    assert not any(e.type == "error" for e in events)
+    assert any(e.type == "text" for e in events)
+
+    sent = client.last_request["json"]["messages"]
+    assistant_tc = [m for m in sent if m.get("role") == "assistant" and m.get("tool_calls")]
+    # Les deux tours (rejoué + courant) sont présents et SANS content non vide
+    assert len(assistant_tc) == 2
+    for m in assistant_tc:
+        assert not (m.get("content") or "").strip(), "content non vide + tool_calls = 400 Mistral"
+    tool_msgs = [m for m in sent if m.get("role") == "tool"]
+    assert [t["tool_call_id"] for t in tool_msgs] == ["call_1", "call_2"]

--- a/tests/test_routers_calendar.py
+++ b/tests/test_routers_calendar.py
@@ -739,3 +739,9 @@ class TestGoogle403Actionnable:
         assert exc.value.status_code == 403
         assert "Google Calendar" in exc.value.detail
         assert "console Google Cloud" in exc.value.detail
+        # BUG-109 / boucle "connexion expirée" (lcjp 12/06/2026) : le message ne
+        # doit PAS contenir le radical "reconnect" — sinon l'heuristique du
+        # CalendarPanel (msg.includes('reconnect')) le classe à tort comme un
+        # jeton expiré, masque ce message actionnable et déclenche une boucle de
+        # reconnexion infinie. Un 403 = config serveur Google, pas une expiration.
+        assert "reconnect" not in exc.value.detail.lower()


### PR DESCRIPTION
Corrige les 3 bugs remontés par les testeurs alpha le 12/06/2026 (postérieurs à v0.24.3, aucun n'avait de correctif).

## BUG-108 — boucle lecture des mails (lcjp, Mistral, Windows)
Mistral renvoie un 400 si un message assistant a à la fois du `content` non vide et des `tool_calls`. Le résultat de `read_emails` était perdu → boucle « Max tool iterations » → fausse « erreur d'authentification ».
- `providers/base.py` : un message porteur de `tool_calls` n'embarque plus de texte (`content=None`, valeur canonique OpenAI/litellm). Couvre aussi OpenRouter/Infomaniak → Mistral.
- Test comportemental Mistral ajouté.

## BUG-109 + boucle « connexion expirée » (lcjp, calendrier Google)
Le message 403 contenait « reconnecte », capté par l'heuristique du `CalendarPanel` (`includes('reconnect')`) → fausse expiration, message actionnable masqué, boucle de reconnexion infinie.
- backend : message 403 reformulé sans « reconnecte » (reste actionnable, garde « Google Calendar » + « console Google Cloud »).
- frontend : helper testable `classifyCalendarError`. Un 403 affiche le message actionnable **et désarme** `needsReauth` (un 403 prouve que le jeton est valide ; cet état est partagé avec l'email et une expiration Gmail antérieure pouvait entretenir la boucle). « reconnect » reste détecté pour la vraie expiration.

## BUG-107 — régression historique chat (Capov, macOS)
Une conversation créée par un agent (prép-RDV) est locale non synchronisée. Le clic sidebar interrogeait le backend avec un ID inconnu → `[]` (HTTP 200) → écrasement du message + `synced:true` → disparition de l'historique.
- `chatStore` : ne vide plus une conversation non synchronisée avec une liste vide.
- `ConversationSidebar` : ne fetch que si la conv est synced et vide (même garde que `useConversationSync`).

## Vérification
- Backend complet (hors tests réseau) : vert. Frontend : 231 tests verts. Ruff OK, ESLint 0 erreur.
- 3 tests de régression ajoutés (1 par bug) + 4 tests unitaires du helper calendrier.
- Investigation cause racine + revue adversariale 2 angles avant merge (le must-fix « needsReauth partagé » identifié en revue a été corrigé et testé).

NB : les symptômes Gmail/Calendrier de lcjp sont Windows + Mistral ; les fixes sont vérifiés au niveau code/tests, la confirmation terrain reste à faire par lcjp après release.
