### PR TITLE
fix(ui): BUG-A toggle 'Ouvrir sur le chat directement' (persistance Zustand)

### DIFF
--- a/src/frontend/src/components/chat/ChatLayout.tsx
+++ b/src/frontend/src/components/chat/ChatLayout.tsx
@@ -82,8 +82,14 @@ export function ChatLayout() {
   const ps = usePanelStore();
   const activeView = useNavigationStore((s) => s.activeView);
   const goBack = useNavigationStore((s) => s.goBack);
+  const initializeView = useNavigationStore((s) => s.initializeView);
 
   useEffect(() => { setGuidedPanelActive(false); }, [currentConversationId]);
+
+  // Initialiser la vue selon les préférences utilisateur au montage
+  useEffect(() => {
+    initializeView();
+  }, [initializeView]);
 
   // Insertion d'un prompt dans le chat depuis ailleurs (⌘K « Produire un document »,
   // bibliothèque de prompts) — correctif KO Syn 2.1/2.2 : ramène au chat et pré-remplit.

--- a/src/frontend/src/components/settings/AdvancedTab.tsx
+++ b/src/frontend/src/components/settings/AdvancedTab.tsx
@@ -8,6 +8,7 @@ import { AccessibilityTab } from './AccessibilityTab';
 import { PerformanceTab } from './PerformanceTab';
 import { LimitsTab } from './LimitsTab';
 import { CRMSyncPanel } from './CRMSyncPanel';
+import { usePersonalisationStore } from '../../stores/personalisationStore';
 import * as api from '../../services/api';
 
 export interface AdvancedTabProps {
@@ -131,14 +132,11 @@ export function AdvancedTab({
 }
 
 function StartupBehavior() {
-  const [skipDashboard, setSkipDashboard] = useState(() => {
-    return localStorage.getItem('therese-skip-dashboard') === 'true';
-  });
+  const skipDashboard = usePersonalisationStore((state) => state.skipDashboard ?? false);
+  const setSkipDashboard = usePersonalisationStore((state) => state.setSkipDashboard);
 
   const handleToggle = () => {
-    const newValue = !skipDashboard;
-    setSkipDashboard(newValue);
-    localStorage.setItem('therese-skip-dashboard', newValue ? 'true' : 'false');
+    setSkipDashboard(!skipDashboard);
   };
 
   return (

--- a/src/frontend/src/stores/navigationStore.ts
+++ b/src/frontend/src/stores/navigationStore.ts
@@ -7,6 +7,7 @@
  */
 
 import { create } from 'zustand';
+import { usePersonalisationStore } from './personalisationStore';
 
 export type AppView =
   | 'chat'
@@ -27,10 +28,12 @@ interface NavigationStore {
   setView: (view: AppView) => void;
   goBack: () => void;
   resetToChat: () => void;
+  /** Initialise la vue selon les préférences utilisateur */
+  initializeView: () => void;
 }
 
 export const useNavigationStore = create<NavigationStore>((set) => ({
-  activeView: 'chat',
+  activeView: 'home', // Vue par défaut, sera ajustée par initializeView()
   history: [],
 
   setView: (view) =>
@@ -53,4 +56,12 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
     }),
 
   resetToChat: () => set({ activeView: 'chat', history: [] }),
+
+  initializeView: () => {
+    const skipDashboard = usePersonalisationStore.getState().skipDashboard ?? false;
+    set({ 
+      activeView: skipDashboard ? 'chat' : 'home', 
+      history: [] 
+    });
+  },
 }));

--- a/src/frontend/src/stores/personalisationStore.ts
+++ b/src/frontend/src/stores/personalisationStore.ts
@@ -106,6 +106,29 @@ const DEFAULT_FEATURE_VISIBILITY: FeatureVisibility = {
 };
 
 // ============================================================
+// Migration helper for existing localStorage preferences
+// ============================================================
+
+function migrateFromLocalStorage(): Partial<PersonalisationState> {
+  const migrations: Partial<PersonalisationState> = {};
+  
+  try {
+    // Migrer skipDashboard depuis localStorage
+    const existingSkipDashboard = localStorage.getItem('therese-skip-dashboard');
+    if (existingSkipDashboard !== null) {
+      migrations.skipDashboard = existingSkipDashboard === 'true';
+      // Nettoyer l'ancienne clé localStorage
+      localStorage.removeItem('therese-skip-dashboard');
+    }
+  } catch (error) {
+    // Ignorer les erreurs de localStorage en mode privé, etc.
+    console.warn('Failed to migrate from localStorage:', error);
+  }
+  
+  return migrations;
+}
+
+// ============================================================
 // Store Interface
 // ============================================================
 
@@ -135,97 +158,113 @@ interface PersonalisationState {
   featureVisibility: FeatureVisibility;
   setFeatureVisibility: (visibility: Partial<FeatureVisibility>) => void;
   resetFeatureVisibility: () => void;
+
+  // Comportement au lancement
+  skipDashboard: boolean;
+  setSkipDashboard: (skip: boolean) => void;
 }
 
 export const usePersonalisationStore = create<PersonalisationState>()(
   persist(
-    (set, get) => ({
-      // ============================================================
-      // US-PERS-06: UX Mode
-      // ============================================================
+    (set, get) => {
+      // Effectuer la migration des données localStorage au premier chargement
+      const migrations = migrateFromLocalStorage();
+      
+      return {
+        // ============================================================
+        // US-PERS-06: UX Mode
+        // ============================================================
 
-      uxMode: DEFAULT_UX_MODE,
-      setUXMode: (mode) => set({ uxMode: mode }),
+        uxMode: DEFAULT_UX_MODE,
+        setUXMode: (mode) => set({ uxMode: mode }),
 
-      // ============================================================
-      // US-PERS-01: Keyboard Shortcuts
-      // ============================================================
+        // ============================================================
+        // US-PERS-01: Keyboard Shortcuts
+        // ============================================================
 
-      shortcuts: DEFAULT_SHORTCUTS,
+        shortcuts: DEFAULT_SHORTCUTS,
 
-      setShortcut: (action, key, modifiers) => {
-        set((state) => ({
-          shortcuts: state.shortcuts.map((s) =>
-            s.action === action ? { ...s, key, modifiers } : s
-          ),
-        }));
-      },
+        setShortcut: (action, key, modifiers) => {
+          set((state) => ({
+            shortcuts: state.shortcuts.map((s) =>
+              s.action === action ? { ...s, key, modifiers } : s
+            ),
+          }));
+        },
 
-      resetShortcuts: () => set({ shortcuts: DEFAULT_SHORTCUTS }),
+        resetShortcuts: () => set({ shortcuts: DEFAULT_SHORTCUTS }),
 
-      getShortcutForAction: (action) => {
-        return get().shortcuts.find((s) => s.action === action);
-      },
+        getShortcutForAction: (action) => {
+          return get().shortcuts.find((s) => s.action === action);
+        },
 
-      // ============================================================
-      // US-PERS-02: Prompt Templates
-      // ============================================================
+        // ============================================================
+        // US-PERS-02: Prompt Templates
+        // ============================================================
 
-      promptTemplates: [],
+        promptTemplates: [],
 
-      addPromptTemplate: (template) => {
-        const newTemplate: PromptTemplate = {
-          ...template,
-          id: crypto.randomUUID(),
-          createdAt: new Date(),
-        };
-        set((state) => ({
-          promptTemplates: [...state.promptTemplates, newTemplate],
-        }));
-      },
+        addPromptTemplate: (template) => {
+          const newTemplate: PromptTemplate = {
+            ...template,
+            id: crypto.randomUUID(),
+            createdAt: new Date(),
+          };
+          set((state) => ({
+            promptTemplates: [...state.promptTemplates, newTemplate],
+          }));
+        },
 
-      removePromptTemplate: (id) => {
-        set((state) => ({
-          promptTemplates: state.promptTemplates.filter((t) => t.id !== id),
-        }));
-      },
+        removePromptTemplate: (id) => {
+          set((state) => ({
+            promptTemplates: state.promptTemplates.filter((t) => t.id !== id),
+          }));
+        },
 
-      updatePromptTemplate: (id, updates) => {
-        set((state) => ({
-          promptTemplates: state.promptTemplates.map((t) =>
-            t.id === id ? { ...t, ...updates } : t
-          ),
-        }));
-      },
+        updatePromptTemplate: (id, updates) => {
+          set((state) => ({
+            promptTemplates: state.promptTemplates.map((t) =>
+              t.id === id ? { ...t, ...updates } : t
+            ),
+          }));
+        },
 
-      // ============================================================
-      // US-PERS-04: LLM Behavior
-      // ============================================================
+        // ============================================================
+        // US-PERS-04: LLM Behavior
+        // ============================================================
 
-      llmBehavior: DEFAULT_LLM_BEHAVIOR,
+        llmBehavior: DEFAULT_LLM_BEHAVIOR,
 
-      setLLMBehavior: (behavior) => {
-        set((state) => ({
-          llmBehavior: { ...state.llmBehavior, ...behavior },
-        }));
-      },
+        setLLMBehavior: (behavior) => {
+          set((state) => ({
+            llmBehavior: { ...state.llmBehavior, ...behavior },
+          }));
+        },
 
-      resetLLMBehavior: () => set({ llmBehavior: DEFAULT_LLM_BEHAVIOR }),
+        resetLLMBehavior: () => set({ llmBehavior: DEFAULT_LLM_BEHAVIOR }),
 
-      // ============================================================
-      // US-PERS-05: Feature Visibility
-      // ============================================================
+        // ============================================================
+        // US-PERS-05: Feature Visibility
+        // ============================================================
 
-      featureVisibility: DEFAULT_FEATURE_VISIBILITY,
+        featureVisibility: DEFAULT_FEATURE_VISIBILITY,
 
-      setFeatureVisibility: (visibility) => {
-        set((state) => ({
-          featureVisibility: { ...state.featureVisibility, ...visibility },
-        }));
-      },
+        setFeatureVisibility: (visibility) => {
+          set((state) => ({
+            featureVisibility: { ...state.featureVisibility, ...visibility },
+          }));
+        },
 
-      resetFeatureVisibility: () => set({ featureVisibility: DEFAULT_FEATURE_VISIBILITY }),
-    }),
+        resetFeatureVisibility: () => set({ featureVisibility: DEFAULT_FEATURE_VISIBILITY }),
+
+        // ============================================================
+        // Comportement au lancement
+        // ============================================================
+
+        skipDashboard: migrations.skipDashboard ?? false,
+        setSkipDashboard: (skip) => set({ skipDashboard: skip }),
+      };
+    },
     {
       name: 'therese-personalisation',
     }

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -7465,3 +7465,110 @@ class TestDeepResearchSurfacesSynthesisError:
         synth = self._synthesis_section()
         assert 'type="error"' in synth, "une erreur de synthèse doit émettre un ResearchProgress type='error'"
         assert "La synthèse a échoué" in synth
+
+class TestBUGA_ToggleOuvrirChatDirectement:
+    """BUG-A : Toggle 'Ouvrir sur le chat directement' sans effet (Réglages)
+    
+    Le toggle ne bascule pas visuellement et la préférence n'est pas persistée.
+    Causes : état local React au lieu de store Zustand global, pas de persistance centralisée.
+    """
+
+    PERSONALISATION_STORE = FRONTEND / "stores" / "personalisationStore.ts"
+    ADVANCED_TAB = FRONTEND / "components" / "settings" / "AdvancedTab.tsx"
+    NAVIGATION_STORE = FRONTEND / "stores" / "navigationStore.ts"
+
+    def test_personalisation_store_has_skip_dashboard_preference(self):
+        """Le store de personnalisation doit avoir une préférence skipDashboard"""
+        content = self.PERSONALISATION_STORE.read_text(encoding="utf-8")
+        
+        # Vérifier que la préférence est définie dans l'interface
+        assert "skipDashboard: boolean" in content, (
+            "l'interface PersonalisationState doit déclarer skipDashboard: boolean"
+        )
+        
+        # Vérifier qu'il y a un setter
+        assert "setSkipDashboard:" in content, (
+            "le store doit avoir une action setSkipDashboard"
+        )
+        
+        # Vérifier que la valeur par défaut est false (afficher dashboard par défaut)
+        assert "?? false" in content, (
+            "la valeur par défaut de skipDashboard doit être false"
+        )
+
+    def test_startup_behavior_uses_zustand_store(self):
+        """Le composant StartupBehavior doit utiliser le store Zustand au lieu d'état local"""
+        content = self.ADVANCED_TAB.read_text(encoding="utf-8")
+        
+        # Vérifier l'import du store
+        assert "usePersonalisationStore" in content, (
+            "AdvancedTab doit importer usePersonalisationStore"
+        )
+        
+        # Le composant StartupBehavior ne doit plus utiliser useState local
+        startup_behavior_start = content.find("function StartupBehavior()")
+        startup_behavior_end = content.find("}", startup_behavior_start) + 1
+        startup_behavior_code = content[startup_behavior_start:startup_behavior_end]
+        
+        assert "useState" not in startup_behavior_code, (
+            "StartupBehavior ne doit plus utiliser useState local"
+        )
+        
+        # Doit utiliser le store Zustand
+        assert "usePersonalisationStore" in startup_behavior_code, (
+            "StartupBehavior doit utiliser usePersonalisationStore"
+        )
+        
+        # Ne doit plus utiliser localStorage directement
+        assert "localStorage.getItem('therese-skip-dashboard')" not in startup_behavior_code, (
+            "StartupBehavior ne doit plus accéder directement à localStorage"
+        )
+        
+    def test_navigation_store_respects_skip_dashboard(self):
+        """Le navigationStore doit initialiser activeView selon la préférence skipDashboard"""
+        content = self.NAVIGATION_STORE.read_text(encoding="utf-8")
+        
+        # Vérifier l'import du store de personnalisation
+        assert "usePersonalisationStore" in content, (
+            "navigationStore doit importer usePersonalisationStore"
+        )
+        
+        # Vérifier que l'initialisation de activeView prend en compte skipDashboard
+        # Soit via une fonction d'initialisation, soit via un effet
+        assert "skipDashboard" in content, (
+            "navigationStore doit consulter la préférence skipDashboard pour déterminer la vue initiale"
+        )
+
+    def test_migration_from_localstorage(self):
+        """La migration depuis localStorage doit être implémentée"""
+        content = self.PERSONALISATION_STORE.read_text(encoding="utf-8")
+        
+        # Vérifier qu'il y a une fonction de migration
+        assert "migrateFromLocalStorage" in content, (
+            "le store doit avoir une fonction migrateFromLocalStorage"
+        )
+        
+        # Vérifier que la migration cherche l'ancienne clé
+        assert "therese-skip-dashboard" in content, (
+            "la migration doit chercher l'ancienne clé therese-skip-dashboard"
+        )
+        
+        # Vérifier que la migration nettoie l'ancienne clé
+        assert "removeItem" in content, (
+            "la migration doit nettoyer l'ancienne clé localStorage"
+        )
+
+    def test_fallbacks_for_undefined_values(self):
+        """Les composants doivent avoir des fallbacks pour les valeurs non définies"""
+        advanced_content = self.ADVANCED_TAB.read_text(encoding="utf-8")
+        nav_content = self.NAVIGATION_STORE.read_text(encoding="utf-8")
+        
+        # Vérifier les fallbacks dans StartupBehavior
+        assert "?? false" in advanced_content, (
+            "StartupBehavior doit avoir un fallback ?? false pour skipDashboard"
+        )
+        
+        # Vérifier les fallbacks dans navigationStore
+        assert "?? false" in nav_content, (
+            "navigationStore doit avoir un fallback ?? false pour skipDashboard"
+        )


### PR DESCRIPTION
## BUG-A — Toggle "Ouvrir sur le chat directement" sans effet

Signalé par Ludo (18/06). Corrigé par Zézette (tournée de nuit 19/06).

**Cause** : la préférence était en état local React (`useState`) au lieu du store global, sans persistance centralisée → le toggle ne basculait pas / ne tenait pas.

**Fix** :
- Préférence `skipDashboard` dans `personalisationStore` avec persistance Zustand.
- Migration automatique depuis `localStorage` (`therese-skip-dashboard`) vers Zustand.
- `StartupBehavior` passe des `useState`+localStorage aux hooks Zustand.
- Initialisation de la vue (home vs chat) selon la préférence dans `navigationStore`.
- Fallbacks (`?? false`) pour valeurs non définies.
- 5 tests de régression (migration, fallbacks, comportement).

Validation Zézette : 5/5 tests BUG-A, régression complète, lint OK.
PR ouverte depuis le Mac (le `gh pr create` de Zézette est encore bloqué, mais son `git push` passe via la clé SSH).
