### PR TITLE
fix(crm): BUG-B message actionnable quand la feuille CRM synchronisée est vide

### DIFF
--- a/src/backend/app/routers/crm.py
+++ b/src/backend/app/routers/crm.py
@@ -1185,7 +1185,11 @@ async def handle_sheets_oauth_callback(
     if spreadsheet_info:
         result["spreadsheet_id"] = spreadsheet_info["spreadsheet_id"]
         result["spreadsheet_url"] = spreadsheet_info["spreadsheet_url"]
-        result["message"] = "Google Sheets connecté et CRM créé automatiquement"
+        result["message"] = (
+            "Google Sheets connecté. Une nouvelle feuille CRM vide a été créée. "
+            "Si tu as déjà un CRM dans Google Sheets, colle son identifiant dans "
+            "Réglages > Synchronisation CRM puis resynchronise."
+        )
 
     return result
 
@@ -1224,7 +1228,7 @@ async def sync_crm(
     api_key = None
 
     # Try OAuth token first (avec refresh automatique si expiré)
-    from app.services.crm_sync import ensure_valid_crm_token
+    from app.services.crm_sync import build_sync_message, ensure_valid_crm_token
     access_token = await ensure_valid_crm_token(session)
     if access_token:
         logger.info("Using OAuth token for CRM sync (auto-refreshed if needed)")
@@ -1337,7 +1341,7 @@ async def sync_crm(
 
         return CRMSyncResponse(
             success=len(stats["errors"]) == 0,
-            message=f"Synchronisation terminee: {total_synced} elements",
+            message=build_sync_message(total_synced, bool(stats["errors"])),
             stats=CRMSyncStatsResponse(**stats, total_synced=total_synced),
             sync_time=now,
         )

--- a/src/backend/app/services/crm_sync.py
+++ b/src/backend/app/services/crm_sync.py
@@ -519,6 +519,23 @@ async def auto_create_crm_spreadsheet(
     }
 
 
+def build_sync_message(total_synced: int, has_errors: bool) -> str:
+    """Message de fin de synchro CRM, actionnable quand la feuille est vide (BUG-B).
+
+    0 element sans erreur = feuille vide : on guide l'utilisateur vers l'option
+    'feuille existante' (au lieu de la feuille vide auto-creee a la connexion),
+    au lieu de laisser un CRM vide sans explication.
+    """
+    if total_synced == 0 and not has_errors:
+        return (
+            "Synchronisation terminee : 0 element. La feuille Google synchronisee "
+            "est vide. Si tu as deja un CRM dans Google Sheets, renseigne son "
+            "identifiant dans Reglages > Synchronisation CRM (champ ID de la "
+            "feuille), puis resynchronise."
+        )
+    return f"Synchronisation terminee: {total_synced} elements"
+
+
 async def get_crm_access_token(session: AsyncSession) -> str | None:
     """Get decrypted CRM Sheets access token."""
     from app.services.encryption import decrypt_value

--- a/src/backend/tests/test_crm_sync_message.py
+++ b/src/backend/tests/test_crm_sync_message.py
@@ -1,0 +1,29 @@
+"""BUG-B : message de synchro CRM actionnable quand la feuille est vide.
+
+Quand l'utilisateur connecte Google sans renseigner d'ID, Thérèse crée une feuille
+vide et la synchro remonte 0 element, sans explication. On guide vers l'option
+'feuille existante'.
+"""
+
+from app.services.crm_sync import build_sync_message
+
+
+def test_message_normal_quand_elements_synchronises():
+    msg = build_sync_message(5, has_errors=False)
+    assert "5" in msg
+    assert "vide" not in msg.lower()
+
+
+def test_message_vide_guide_vers_feuille_existante():
+    msg = build_sync_message(0, has_errors=False)
+    low = msg.lower()
+    assert "vide" in low
+    # doit expliquer comment pointer vers une feuille existante
+    assert "identifiant" in low or "id de la feuille" in low
+    assert "synchron" in low  # invite a resynchroniser
+
+
+def test_message_zero_avec_erreurs_nest_pas_le_message_feuille_vide():
+    # 0 element MAIS des erreurs => c'est un echec, pas une feuille vide.
+    msg = build_sync_message(0, has_errors=True)
+    assert "vide" not in msg.lower()


### PR DESCRIPTION
BUG-B (signalé par Ludo). À la 1re connexion Google sans ID de feuille, Thérèse crée une feuille vide et la synchro remonte 0 élément sans explication → CRM blanc. Fix : message de synchro qui guide vers l'option feuille existante (coller l'ID dans Réglages puis resynchroniser) + message de connexion honnête. Fonction pure build_sync_message + 3 tests TDD. Suite et déblocage UX complet (choix de feuille au moment de la connexion) = follow-up noté.