### PR TITLE
feat(crm): BUG-B choix d'une feuille Google Sheets existante (CRM sync)

### DIFF
--- a/src/backend/app/routers/crm.py
+++ b/src/backend/app/routers/crm.py
@@ -1198,15 +1198,13 @@ async def handle_sheets_oauth_callback(
 async def list_google_sheets(
     session: AsyncSession = Depends(get_session),
 ):
-    """
-    Liste les feuilles Google Sheets de l'utilisateur pour permettre de choisir 
+    """Liste les feuilles Google Sheets de l'utilisateur pour permettre de choisir
     une feuille existante au lieu de créer automatiquement une feuille vide (BUG-B).
-    
+
     Utilise l'API Google Drive pour lister les fichiers de type spreadsheet.
     """
-    from app.services.crm_sync import ensure_valid_crm_token
-    from app.services.sheets_service import GoogleSheetsService
     import httpx
+    from app.services.crm_sync import ensure_valid_crm_token
 
     # Vérifier le token OAuth
     access_token = await ensure_valid_crm_token(session)
@@ -1243,7 +1241,7 @@ async def list_google_sheets(
 
         data = response.json()
         sheets = []
-        
+
         for file in data.get("files", []):
             sheets.append({
                 "id": file["id"],

--- a/src/backend/app/routers/crm.py
+++ b/src/backend/app/routers/crm.py
@@ -1194,6 +1194,84 @@ async def handle_sheets_oauth_callback(
     return result
 
 
+@router.get("/google-sheets/list")
+async def list_google_sheets(
+    session: AsyncSession = Depends(get_session),
+):
+    """
+    Liste les feuilles Google Sheets de l'utilisateur pour permettre de choisir 
+    une feuille existante au lieu de créer automatiquement une feuille vide (BUG-B).
+    
+    Utilise l'API Google Drive pour lister les fichiers de type spreadsheet.
+    """
+    from app.services.crm_sync import ensure_valid_crm_token
+    from app.services.sheets_service import GoogleSheetsService
+    import httpx
+
+    # Vérifier le token OAuth
+    access_token = await ensure_valid_crm_token(session)
+    if not access_token:
+        raise HTTPException(
+            status_code=401,
+            detail="Authentification Google Sheets requise. Connectez-vous d'abord."
+        )
+
+    try:
+        # Utiliser l'API Google Drive pour lister les spreadsheets
+        async with httpx.AsyncClient(timeout=httpx.Timeout(connect=5.0, read=30.0)) as client:
+            response = await client.get(
+                "https://www.googleapis.com/drive/v3/files",
+                headers={"Authorization": f"Bearer {access_token}"},
+                params={
+                    "q": "mimeType='application/vnd.google-apps.spreadsheet' and trashed=false",
+                    "fields": "nextPageToken, files(id, name, modifiedTime)",
+                    "orderBy": "modifiedTime desc",
+                    "pageSize": 20,  # Limiter à 20 feuilles récentes
+                },
+            )
+
+        if response.status_code == 401:
+            raise HTTPException(
+                status_code=401,
+                detail="Token Google Sheets expiré. Reconnectez-vous."
+            )
+        elif response.status_code != 200:
+            raise HTTPException(
+                status_code=response.status_code,
+                detail=f"Erreur API Google Drive : {response.text}"
+            )
+
+        data = response.json()
+        sheets = []
+        
+        for file in data.get("files", []):
+            sheets.append({
+                "id": file["id"],
+                "name": file["name"],
+                "modified_time": file.get("modifiedTime"),
+                "url": f"https://docs.google.com/spreadsheets/d/{file['id']}/edit"
+            })
+
+        return {
+            "sheets": sheets,
+            "total": len(sheets),
+            "message": f"{len(sheets)} feuille(s) trouvée(s)"
+        }
+
+    except httpx.RequestError as e:
+        logger.error(f"Erreur réseau lors de la liste des feuilles Google : {e}")
+        raise HTTPException(
+            status_code=503,
+            detail="Impossible de contacter Google Drive. Vérifiez votre connexion."
+        )
+    except Exception as e:
+        logger.error(f"Erreur interne lors de la liste des feuilles Google : {e}")
+        raise HTTPException(
+            status_code=500,
+            detail="Erreur interne lors de la récupération des feuilles"
+        )
+
+
 @router.post("/sync", response_model=CRMSyncResponse)
 async def sync_crm(
     session: AsyncSession = Depends(get_session),

--- a/src/frontend/src/components/settings/CRMSyncPanel.tsx
+++ b/src/frontend/src/components/settings/CRMSyncPanel.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { RefreshCw, Link2, Check, AlertCircle, Loader2, ExternalLink, Cloud, Key, Upload } from 'lucide-react';
+import { RefreshCw, Link2, Check, AlertCircle, Loader2, ExternalLink, Cloud, Key, Upload, List, Search } from 'lucide-react';
 import { Button } from '../ui/Button';
 import * as api from '../../services/api';
 
@@ -27,6 +27,12 @@ export function CRMSyncPanel({ onSyncComplete }: CRMSyncPanelProps) {
   const [success, setSuccess] = useState<string | null>(null);
   const [lastSyncStats, setLastSyncStats] = useState<api.CRMSyncStats | null>(null);
   const [spreadsheetId, setSpreadsheetId] = useState(DEFAULT_SPREADSHEET_ID);
+
+  // BUG-B : choix feuille existante
+  const [showExistingSheets, setShowExistingSheets] = useState(false);
+  const [existingSheets, setExistingSheets] = useState<any[]>([]);
+  const [loadingSheets, setLoadingSheets] = useState(false);
+  const [sheetSearch, setSheetSearch] = useState('');
 
   // F-13 : formulaire re-saisie credentials Google OAuth
   const [showCredentialsForm, setShowCredentialsForm] = useState(false);
@@ -182,6 +188,56 @@ export function CRMSyncPanel({ onSyncComplete }: CRMSyncPanelProps) {
     }
   };
 
+  // BUG-B : charger les feuilles Google existantes
+  const handleLoadExistingSheets = async () => {
+    try {
+      setLoadingSheets(true);
+      setError(null);
+
+      const response = await fetch('/api/crm/google-sheets/list', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (response.status === 401) {
+        setError('Authentification Google Sheets requise. Connectez-vous d\'abord.');
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(`Erreur ${response.status}: ${await response.text()}`);
+      }
+
+      const data = await response.json();
+      setExistingSheets(data.sheets || []);
+      setShowExistingSheets(true);
+      
+      if (data.sheets?.length === 0) {
+        setError('Aucune feuille Google Sheets trouvée dans votre compte.');
+      }
+    } catch (err: any) {
+      console.error('Erreur lors du chargement des feuilles:', err);
+      setError(err.message || 'Impossible de charger les feuilles existantes');
+    } finally {
+      setLoadingSheets(false);
+    }
+  };
+
+  // BUG-B : sélectionner une feuille existante
+  const handleSelectExistingSheet = (sheet: any) => {
+    setSpreadsheetId(sheet.id);
+    setShowExistingSheets(false);
+    setSuccess(`Feuille sélectionnée : ${sheet.name}`);
+    setTimeout(() => setSuccess(null), 3000);
+  };
+
+  // BUG-B : filtrer les feuilles par recherche
+  const filteredSheets = existingSheets.filter((sheet) =>
+    sheet.name.toLowerCase().includes(sheetSearch.toLowerCase())
+  );
+
   const handleSync = async () => {
     try {
       setSyncing(true);
@@ -259,6 +315,100 @@ export function CRMSyncPanel({ onSyncComplete }: CRMSyncPanelProps) {
       {/* Spreadsheet ID configuration */}
       <div className="space-y-2">
         <label className="text-sm text-text-muted">ID du Google Spreadsheet CRM</label>
+        
+        {/* BUG-B : Bouton pour choisir une feuille existante */}
+        <div className="mb-3 flex gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleLoadExistingSheets}
+            disabled={loadingSheets || !config?.google_auth_configured}
+            className="flex items-center gap-2"
+          >
+            {loadingSheets ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <List className="w-4 h-4" />
+            )}
+            {loadingSheets ? 'Chargement...' : 'Choisir une feuille existante'}
+          </Button>
+          <span className="text-xs text-text-muted self-center">
+            ou entrez l'ID manuellement ci-dessous
+          </span>
+        </div>
+
+        {/* BUG-B : Liste des feuilles existantes */}
+        {showExistingSheets && (
+          <div className="mb-3 p-3 bg-surface-muted border border-border/50 rounded-lg">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm font-medium text-text">
+                Vos feuilles Google Sheets ({filteredSheets.length})
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowExistingSheets(false)}
+                className="text-xs"
+              >
+                Fermer
+              </Button>
+            </div>
+            
+            {existingSheets.length > 3 && (
+              <div className="mb-2 flex items-center gap-2">
+                <Search className="w-4 h-4 text-text-muted" />
+                <input
+                  type="text"
+                  value={sheetSearch}
+                  onChange={(e) => setSheetSearch(e.target.value)}
+                  placeholder="Rechercher une feuille..."
+                  className="flex-1 px-2 py-1 bg-surface border border-border/50 rounded text-xs text-text placeholder:text-text-muted/50 focus:outline-none focus:ring-1 focus:ring-accent-cyan/50"
+                />
+              </div>
+            )}
+            
+            <div className="max-h-40 overflow-y-auto space-y-1">
+              {filteredSheets.length === 0 ? (
+                <div className="text-xs text-text-muted text-center py-2">
+                  {sheetSearch ? 'Aucune feuille ne correspond à la recherche' : 'Aucune feuille trouvée'}
+                </div>
+              ) : (
+                filteredSheets.map((sheet) => (
+                  <div
+                    key={sheet.id}
+                    className="flex items-center justify-between p-2 hover:bg-surface rounded border border-border/30 cursor-pointer group"
+                    onClick={() => handleSelectExistingSheet(sheet)}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium text-text truncate">
+                        {sheet.name}
+                      </div>
+                      <div className="text-xs text-text-muted truncate">
+                        ID: {sheet.id}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          window.open(sheet.url, '_blank');
+                        }}
+                        className="text-xs p-1"
+                        title="Ouvrir dans Google Sheets"
+                      >
+                        <ExternalLink className="w-3 h-3" />
+                      </Button>
+                      <Check className="w-4 h-4 text-accent-cyan" />
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        )}
+
         <div className="flex gap-2">
           <input
             type="text"

--- a/src/frontend/src/components/settings/CRMSyncPanel.tsx
+++ b/src/frontend/src/components/settings/CRMSyncPanel.tsx
@@ -322,7 +322,7 @@ export function CRMSyncPanel({ onSyncComplete }: CRMSyncPanelProps) {
             variant="ghost"
             size="sm"
             onClick={handleLoadExistingSheets}
-            disabled={loadingSheets || !config?.google_auth_configured}
+            disabled={loadingSheets || !config?.has_token}
             className="flex items-center gap-2"
           >
             {loadingSheets ? (

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -7572,3 +7572,48 @@ class TestBUGA_ToggleOuvrirChatDirectement:
         assert "?? false" in nav_content, (
             "navigationStore doit avoir un fallback ?? false pour skipDashboard"
         )
+
+
+class TestBUGB_CrmSyncChoixFeuille:
+    """BUG-B : synchro CRM doit proposer le choix d'une feuille existante avant création automatique.
+    
+    À la première connexion Google sans ID de feuille renseigné, le système créait automatiquement 
+    une feuille vide et synchronisait dessus, résultant en un CRM vide sans explication. 
+    La solution : proposer de choisir une feuille existante AVANT toute création.
+    """
+    
+    def test_backend_api_lister_feuilles_google_disponible(self):
+        """Le backend doit exposer un endpoint pour lister les feuilles Google de l'utilisateur."""
+        from fastapi.testclient import TestClient
+        from app.main import app
+        
+        client = TestClient(app)
+        
+        # L'endpoint doit exister (même si non authentifié, il doit renvoyer 401 ou 403, pas 404)
+        response = client.get("/api/crm/google-sheets/list")
+        assert response.status_code != 404, (
+            "L'endpoint /api/crm/google-sheets/list doit exister pour lister les feuilles existantes"
+        )
+        
+    def test_frontend_interface_choix_feuille_existante(self):
+        """L'interface CRMSyncPanel doit permettre de choisir parmi les feuilles existantes."""
+        import os
+        crm_panel_path = os.path.join(
+            os.path.dirname(__file__), 
+            "..", "src", "frontend", "src", "components", "settings", "CRMSyncPanel.tsx"
+        )
+        
+        with open(crm_panel_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+            
+        # Doit avoir une fonctionnalité pour lister les feuilles existantes
+        has_list_functionality = (
+            "list" in content.lower() and 
+            ("spreadsheet" in content.lower() or "feuille" in content.lower()) and
+            ("existing" in content.lower() or "existant" in content.lower() or "choisir" in content.lower())
+        )
+        
+        assert has_list_functionality, (
+            "CRMSyncPanel doit proposer de choisir parmi les feuilles existantes, "
+            "pas seulement permettre la saisie manuelle d'un ID"
+        )


### PR DESCRIPTION
## BUG-B (déblocage complet) — Choix d'une feuille CRM existante

Suite du fix BUG-B : au lieu de subir une feuille vide auto-créée, l'utilisateur peut **choisir une feuille Google Sheets existante** à la connexion. Travail Zézette (nuit du 23/06), branche poussée via SSH (son `gh pr create` est encore cassé, PR ouverte depuis le Mac).

**Backend** (`src/backend/app/routers/crm.py`)
- Nouvel endpoint `GET /api/crm/google-sheets/list` (Google Drive API v3, scope readonly) qui liste les spreadsheets de l'utilisateur (ID, nom, URL).

**Frontend** (`src/frontend/src/components/settings/CRMSyncPanel.tsx`)
- Bouton « Choisir une feuille existante » + liste (recherche si >3 feuilles), états de chargement/erreur, auto-remplissage de l'ID, ouverture directe dans Sheets, fallback saisie manuelle.

**Tests** : `TestBUGB_CrmSyncChoixFeuille` (backend endpoint + intégration UI). Zézette annonce 551/551 en local.

NB : à valider par la CI — la tentative de la nuit du 22/06 avait laissé `CRMSyncPanel.tsx` cassé (build frontend en échec), corrigé dans la version du 23/06. La CI Frontend est le juge de paix.
