### PR TITLE
fix(installer): BUG-111 désinstall Windows supprime aussi les données ~/.therese

### DIFF
--- a/src/frontend/src-tauri/installer-hooks.nsh
+++ b/src/frontend/src-tauri/installer-hooks.nsh
@@ -1,0 +1,22 @@
+; Hooks NSIS personnalises pour l'installeur Windows de THERESE (Tauri v2).
+;
+; BUG-111 : a la desinstallation, quand l'utilisateur coche
+; "Supprimer les donnees de l'application", Tauri efface bien les dossiers
+; standards de l'app ($APPDATA / $LOCALAPPDATA\fr.synoptia.therese), MAIS pas
+; le dossier de donnees backend de THERESE, situe dans le profil utilisateur
+; (~/.therese, soit $PROFILE\.therese sous Windows). Resultat : parametrages,
+; projets, conversations, comptes etc. survivaient a une desinstall "avec
+; suppression des donnees", empechant de repartir d'un profil vierge.
+;
+; Ce hook s'execute APRES le bloc de suppression standard de Tauri, dans la
+; section de desinstallation. La variable $DeleteAppDataCheckboxState vaut 1
+; quand la case "supprimer les donnees" a ete cochee : on supprime alors aussi
+; le dossier de donnees backend.
+
+!macro NSIS_HOOK_POSTUNINSTALL
+  ${If} $DeleteAppDataCheckboxState = 1
+    ; Dossier de donnees backend THERESE (db, parametrages, projets, images,
+    ; conversations, comptes, cle de chiffrement...).
+    RMDir /r "$PROFILE\.therese"
+  ${EndIf}
+!macroend

--- a/src/frontend/src-tauri/tauri.conf.json
+++ b/src/frontend/src-tauri/tauri.conf.json
@@ -55,6 +55,9 @@
     "windows": {
       "webviewInstallMode": {
         "type": "downloadBootstrapper"
+      },
+      "nsis": {
+        "installerHooks": "installer-hooks.nsh"
       }
     }
   },

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -7617,3 +7617,51 @@ class TestBUGB_CrmSyncChoixFeuille:
             "CRMSyncPanel doit proposer de choisir parmi les feuilles existantes, "
             "pas seulement permettre la saisie manuelle d'un ID"
         )
+
+
+class TestBUG111_UninstallDeleteData:
+    """BUG-111 : la désinstallation Windows avec « supprimer les données » cochée
+    ne supprimait pas le dossier de données backend (~/.therese), laissant
+    paramétrages et projets en place. Fix : hook NSIS POSTUNINSTALL conditionnel.
+    """
+
+    def _src_tauri(self):
+        import os
+        return os.path.join(
+            os.path.dirname(__file__), "..", "src", "frontend", "src-tauri"
+        )
+
+    def test_hook_nsis_supprime_dossier_therese(self):
+        import os
+        hook_path = os.path.join(self._src_tauri(), "installer-hooks.nsh")
+        assert os.path.exists(hook_path), (
+            "Le hook NSIS installer-hooks.nsh doit exister (BUG-111)"
+        )
+        with open(hook_path, encoding="utf-8") as f:
+            content = f.read()
+        assert "NSIS_HOOK_POSTUNINSTALL" in content, (
+            "Le hook doit definir la macro NSIS_HOOK_POSTUNINSTALL"
+        )
+        assert "DeleteAppDataCheckboxState" in content, (
+            "Le hook ne doit supprimer que si la case 'supprimer les donnees' est cochee"
+        )
+        assert ".therese" in content and "RMDir /r" in content, (
+            "Le hook doit supprimer recursivement le dossier de donnees ~/.therese"
+        )
+
+    def test_tauri_conf_reference_le_hook(self):
+        import json
+        import os
+        conf_path = os.path.join(self._src_tauri(), "tauri.conf.json")
+        with open(conf_path, encoding="utf-8") as f:
+            conf = json.load(f)
+        hooks = (
+            conf.get("bundle", {})
+            .get("windows", {})
+            .get("nsis", {})
+            .get("installerHooks")
+        )
+        assert hooks == "installer-hooks.nsh", (
+            "tauri.conf.json doit referencer installer-hooks.nsh "
+            "via bundle.windows.nsis.installerHooks"
+        )


### PR DESCRIPTION
BUG-111 (Dr_logic-3D, Windows 10). À la désinstallation avec « supprimer les données » cochée, Tauri efface `$APPDATA/$LOCALAPPDATA` mais pas le dossier backend `~/.therese` (paramétrages, projets, conversations, comptes restaient). Fix : hook NSIS `NSIS_HOOK_POSTUNINSTALL` (installer-hooks.nsh) qui supprime `$PROFILE\.therese` quand `$DeleteAppDataCheckboxState = 1`, câblé via `bundle.windows.nsis.installerHooks`. 2 tests de régression. Validation finale réelle sur Windows à faire par le testeur. Suivi noté : UX « lister les données + confirmer » avant suppression.