### PR TITLE
feat(voice): STT/TTS local souverain en option (faster-whisper + Piper, prérequis RAM)

### DIFF
--- a/docs/VOICE-LOCAL.md
+++ b/docs/VOICE-LOCAL.md
@@ -1,0 +1,63 @@
+# Voix locale souveraine (STT + TTS) — option
+
+THÉRÈSE peut fonctionner avec une voix **100 % locale et souveraine**, sans envoyer
+l'audio à un service cloud. C'est une **option** : elle n'est pas incluse par défaut
+pour garder le paquet léger. Tu l'installes seulement si tu en as besoin.
+
+- **STT** (reconnaissance vocale) : [faster-whisper](https://github.com/SYSTRAN/faster-whisper) (Whisper via CTranslate2, CPU, quantization int8).
+- **TTS** (synthèse vocale) : [Piper](https://github.com/rhasspy/piper) (modèles ONNX légers, CPU).
+
+Les deux sont open source et tournent entièrement sur ta machine. C'est l'alternative
+souveraine à la transcription via Groq Whisper (cloud) déjà présente.
+
+## Installation (option)
+
+```bash
+pip install 'therese-backend[voice-local]'
+```
+
+Les **modèles se téléchargent au premier usage** (ils ne sont pas dans le paquet).
+Ensuite, active la voix locale dans les réglages (`voice_local_enabled`).
+
+## Prérequis RAM
+
+### STT — modèles Whisper (faster-whisper, CPU int8)
+
+| Modèle | Taille disque | RAM nécessaire | Qualité |
+|--------|---------------|----------------|---------|
+| `tiny` | ~75 Mo | ~1 Go | Basique, très rapide |
+| `base` (recommandé) | ~145 Mo | ~1 Go | Bon compromis FR |
+| `small` | ~480 Mo | ~2 Go | Meilleure, plus lourde |
+
+Le modèle par défaut est `base`. Choix via le réglage `voice_local_whisper_model`
+(`tiny` | `base` | `small`).
+
+### TTS — Piper
+
+| Composant | Taille disque | RAM nécessaire |
+|-----------|---------------|----------------|
+| 1 voix Piper (ex. `fr_FR-siwis-medium`) | ~60–110 Mo | ~0,5 Go |
+
+> Repère pratique : prévoir **~2 Go de RAM libre** pour un confort STT `base` + TTS
+> en parallèle. Sur une machine avec peu de RAM, rester sur `tiny`.
+
+## Voix Piper (TTS)
+
+Les voix Piper se placent dans `~/.therese/voices/` (fichiers `.onnx` + `.onnx.json`).
+Voix française conseillée : `fr_FR-siwis-medium`. Téléchargement des voix :
+https://github.com/rhasspy/piper/blob/master/VOICES.md
+
+## API
+
+- `GET /api/voice/local/status` — disponibilité (STT/TTS), modèles et prérequis RAM.
+- `POST /api/voice/local/transcribe` — transcription locale (multipart audio).
+- `POST /api/voice/tts` — synthèse vocale locale (`{ "text": "...", "voice": "..." }`) → WAV.
+
+Si le groupe `voice-local` n'est pas installé, ces endpoints renvoient un `503`
+avec l'indication d'installation (jamais de plantage).
+
+## Souveraineté
+
+Avec cette option activée, l'audio (entrée et sortie) ne quitte jamais la machine :
+ni la transcription, ni la synthèse n'appellent un service externe. C'est cohérent
+avec la promesse « assistant IA desktop souverain, données 100 % locales ».

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,14 @@ e2e = [
     "playwright>=1.40.0",
     "pytest-playwright>=0.4.0",
 ]
+# Voix 100% locale et souveraine (STT + TTS), OPTIONNELLE : non incluse dans le
+# build par defaut pour garder le paquet leger. A installer a la demande via
+# `pip install 'therese-backend[voice-local]'`. Modeles telecharges au 1er usage.
+# Prerequis RAM : voir docs/VOICE-LOCAL.md.
+voice-local = [
+    "faster-whisper>=1.0",
+    "piper-tts>=1.2",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -60,6 +60,10 @@ class Settings(BaseSettings):
     chunk_size: int = 500
     chunk_overlap: int = 50
 
+    # Voix locale souveraine (STT/TTS) - OPTIONNELLE (groupe pip 'voice-local')
+    voice_local_enabled: bool = False
+    voice_local_whisper_model: str = "base"  # tiny | base | small
+
     def model_post_init(self, __context) -> None:
         """Initialize paths after settings are loaded."""
         # Set data_dir from env or default

--- a/src/backend/app/models/schemas_voice.py
+++ b/src/backend/app/models/schemas_voice.py
@@ -13,3 +13,10 @@ class TranscriptionResponse(BaseModel):
     text: str
     duration_seconds: float | None = None
     language: str | None = None
+
+
+class TTSRequest(BaseModel):
+    """Requête de synthèse vocale locale (Piper)."""
+
+    text: str
+    voice: str | None = None

--- a/src/backend/app/routers/voice.py
+++ b/src/backend/app/routers/voice.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from app.models.database import get_session
 from app.models.entities import Preference
-from app.models.schemas_voice import TranscriptionResponse
+from app.models.schemas_voice import TranscriptionResponse, TTSRequest
 from app.services.http_client import get_http_client
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -149,3 +149,93 @@ async def transcribe_audio(
             os.unlink(tmp_path)
         except Exception as e:
             logger.debug("Echec nettoyage fichier temp: %s", e)
+
+
+# =============================================================================
+# Voix LOCALE souveraine (STT + TTS) - OPTIONNELLE (groupe pip voice-local)
+# =============================================================================
+
+
+@router.get("/local/status")
+async def voice_local_status_route():
+    """Disponibilité de la voix locale (STT/TTS) + modèles + prérequis RAM.
+
+    Permet à l'UI d'afficher si la voix souveraine est installée, et sinon
+    comment l'activer (et la RAM nécessaire).
+    """
+    from app.services.voice_local import voice_local_status
+
+    return voice_local_status()
+
+
+@router.post("/local/transcribe", response_model=TranscriptionResponse)
+async def transcribe_audio_local(
+    audio: UploadFile = File(...),
+    session: AsyncSession = Depends(get_session),
+):
+    """Transcription 100% locale et souveraine (faster-whisper), sans cloud.
+
+    Nécessite le groupe optionnel `voice-local` installé (sinon 503 + indication).
+    """
+    from app.config import get_settings
+    from app.services.voice_local import stt_available, transcribe_local
+
+    if not stt_available():
+        from app.services.voice_local import INSTALL_HINT
+
+        raise HTTPException(status_code=503, detail=f"Voix locale non installée. {INSTALL_HINT}")
+
+    audio_data = await audio.read()
+    if not audio_data:
+        raise HTTPException(status_code=400, detail="Fichier audio vide")
+
+    extension = Path(audio.filename or "recording.webm").suffix or ".webm"
+    with tempfile.NamedTemporaryFile(suffix=extension, delete=False) as tmp:
+        tmp.write(audio_data)
+        tmp_path = tmp.name
+
+    try:
+        model = get_settings().voice_local_whisper_model
+        text = transcribe_local(tmp_path, model_size=model)
+        return TranscriptionResponse(text=text, language="fr")
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except Exception as e:
+        logger.exception("Erreur transcription locale")
+        raise HTTPException(status_code=500, detail=f"Erreur transcription locale : {e}")
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except Exception as e:
+            logger.debug("Echec nettoyage fichier temp: %s", e)
+
+
+@router.post("/tts")
+async def text_to_speech_local(payload: TTSRequest):
+    """Synthèse vocale 100% locale et souveraine (Piper) -> audio WAV.
+
+    Nécessite le groupe optionnel `voice-local` + la voix téléchargée (sinon 503).
+    """
+    from app.services.voice_local import DEFAULT_PIPER_VOICE, synthesize_local, tts_available
+    from fastapi.responses import FileResponse
+
+    if not tts_available():
+        from app.services.voice_local import INSTALL_HINT
+
+        raise HTTPException(status_code=503, detail=f"Voix locale non installée. {INSTALL_HINT}")
+
+    text = (payload.text or "").strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="Texte vide")
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        out_path = tmp.name
+
+    try:
+        synthesize_local(text, out_path, voice=payload.voice or DEFAULT_PIPER_VOICE)
+        return FileResponse(out_path, media_type="audio/wav", filename="therese-tts.wav")
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except Exception as e:
+        logger.exception("Erreur synthèse vocale locale")
+        raise HTTPException(status_code=500, detail=f"Erreur synthèse vocale locale : {e}")

--- a/src/backend/app/services/voice_local.py
+++ b/src/backend/app/services/voice_local.py
@@ -1,0 +1,122 @@
+"""Voix locale souveraine (STT + TTS) - OPTIONNELLE.
+
+STT : faster-whisper (Whisper via CTranslate2, CPU, int8, léger).
+TTS : Piper (rhasspy, ONNX, CPU, léger).
+
+Ces dépendances sont dans le groupe pip OPTIONNEL `voice-local` (cf pyproject) :
+elles NE SONT PAS incluses dans le build par défaut, pour garder le paquet léger
+et le 100% souverain en option. Les modèles se téléchargent au premier usage.
+
+Prérequis RAM : voir docs/VOICE-LOCAL.md (et WHISPER_MODELS ci-dessous).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Modèles Whisper supportés (faster-whisper, quantization int8 CPU).
+# ram_mb = RAM approximative nécessaire au modèle chargé (hors OS/app).
+WHISPER_MODELS: dict[str, dict] = {
+    "tiny": {"size_mb": 75, "ram_mb": 1024, "label": "Tiny - le plus léger, qualité basique"},
+    "base": {"size_mb": 145, "ram_mb": 1024, "label": "Base - recommandé, bon compromis"},
+    "small": {"size_mb": 480, "ram_mb": 2048, "label": "Small - meilleure qualité, plus lourd"},
+}
+DEFAULT_WHISPER_MODEL = "base"
+
+# Piper TTS : très léger, ~1 voix ONNX (60-110 Mo), faible RAM.
+DEFAULT_PIPER_VOICE = "fr_FR-siwis-medium"
+PIPER_TTS_RAM_MB = 512
+
+INSTALL_HINT = (
+    "Installe la voix locale en option : `pip install 'therese-backend[voice-local]'`. "
+    "Les modèles se téléchargent au premier usage."
+)
+
+
+def stt_available() -> bool:
+    """faster-whisper est-il installé (groupe optionnel voice-local) ?"""
+    return importlib.util.find_spec("faster_whisper") is not None
+
+
+def tts_available() -> bool:
+    """Piper est-il installé (groupe optionnel voice-local) ? (piper-tts -> module `piper`)."""
+    return importlib.util.find_spec("piper") is not None
+
+
+def voices_dir() -> Path:
+    """Dossier où sont rangées les voix Piper téléchargées."""
+    from app.config import get_settings
+
+    return Path(get_settings().data_dir) / "voices"
+
+
+def voice_local_status() -> dict:
+    """État de la voix locale : disponibilité + modèles + prérequis RAM."""
+    from app.config import get_settings
+
+    settings = get_settings()
+    return {
+        "enabled": bool(getattr(settings, "voice_local_enabled", False)),
+        "stt_available": stt_available(),
+        "tts_available": tts_available(),
+        "whisper_models": WHISPER_MODELS,
+        "default_whisper_model": getattr(settings, "voice_local_whisper_model", DEFAULT_WHISPER_MODEL),
+        "tts_voice": DEFAULT_PIPER_VOICE,
+        "tts_ram_mb": PIPER_TTS_RAM_MB,
+        "install_hint": INSTALL_HINT,
+    }
+
+
+_whisper_cache: dict[str, object] = {}
+
+
+def transcribe_local(audio_path: str, model_size: str | None = None, language: str = "fr") -> str:
+    """Transcrit un fichier audio en texte, 100% local (faster-whisper).
+
+    Lève RuntimeError si la dépendance optionnelle n'est pas installée.
+    """
+    if not stt_available():
+        raise RuntimeError(
+            "STT local indisponible : faster-whisper non installé. " + INSTALL_HINT
+        )
+
+    from faster_whisper import WhisperModel  # import paresseux (dépendance optionnelle)
+
+    size = model_size if model_size in WHISPER_MODELS else DEFAULT_WHISPER_MODEL
+    model = _whisper_cache.get(size)
+    if model is None:
+        logger.info("Chargement du modèle Whisper local '%s' (CPU, int8)", size)
+        model = WhisperModel(size, device="cpu", compute_type="int8")
+        _whisper_cache[size] = model
+
+    segments, _info = model.transcribe(audio_path, language=language)
+    return " ".join(seg.text.strip() for seg in segments).strip()
+
+
+def synthesize_local(text: str, out_path: str, voice: str = DEFAULT_PIPER_VOICE) -> str:
+    """Synthétise du texte en audio WAV, 100% local (Piper).
+
+    Lève RuntimeError si la dépendance ou la voix n'est pas disponible.
+    """
+    if not tts_available():
+        raise RuntimeError("TTS local indisponible : Piper non installé. " + INSTALL_HINT)
+
+    import wave
+
+    from piper import PiperVoice  # import paresseux (dépendance optionnelle)
+
+    onnx = voices_dir() / f"{voice}.onnx"
+    if not onnx.exists():
+        raise RuntimeError(
+            f"Voix Piper '{voice}' absente ({onnx}). "
+            "Télécharge-la (voir docs/VOICE-LOCAL.md) puis réessaie."
+        )
+
+    loaded = PiperVoice.load(str(onnx))
+    with wave.open(out_path, "wb") as wav:
+        loaded.synthesize(text, wav)
+    return out_path

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -7665,3 +7665,61 @@ class TestBUG111_UninstallDeleteData:
             "tauri.conf.json doit referencer installer-hooks.nsh "
             "via bundle.windows.nsis.installerHooks"
         )
+
+
+class TestVoiceLocalOption:
+    """Voix locale souveraine STT/TTS, OPTIONNELLE (faster-whisper + Piper).
+
+    Les dépendances ne sont pas installées par défaut : les tests vérifient la
+    structure (modèles + prérequis RAM), la disponibilité, le message clair quand
+    c'est indisponible, le groupe pip optionnel et la doc.
+    """
+
+    def test_status_structure_et_prerequis_ram(self):
+        from app.services.voice_local import WHISPER_MODELS, voice_local_status
+
+        st = voice_local_status()
+        for k in ("stt_available", "tts_available", "whisper_models", "tts_ram_mb", "install_hint"):
+            assert k in st, f"voice_local_status doit exposer '{k}'"
+        # chaque modèle Whisper expose taille disque + prérequis RAM
+        assert WHISPER_MODELS, "WHISPER_MODELS ne doit pas être vide"
+        for _name, info in WHISPER_MODELS.items():
+            assert info.get("ram_mb", 0) > 0, "chaque modèle doit indiquer sa RAM nécessaire"
+            assert info.get("size_mb", 0) > 0
+        assert st["tts_ram_mb"] > 0
+
+    def test_availability_renvoie_bool(self):
+        from app.services.voice_local import stt_available, tts_available
+
+        assert isinstance(stt_available(), bool)
+        assert isinstance(tts_available(), bool)
+
+    def test_transcribe_local_leve_erreur_claire_si_indisponible(self):
+        import pytest
+
+        from app.services import voice_local
+
+        if voice_local.stt_available():
+            pytest.skip("faster-whisper installé localement : cas indisponible non testable")
+        with pytest.raises(RuntimeError):
+            voice_local.transcribe_local("/tmp/inexistant.wav")
+
+    def test_groupe_optionnel_voice_local_dans_pyproject(self):
+        import os
+
+        root = os.path.join(os.path.dirname(__file__), "..")
+        with open(os.path.join(root, "pyproject.toml"), encoding="utf-8") as f:
+            content = f.read()
+        assert "voice-local" in content, "le groupe optionnel voice-local doit exister"
+        assert "faster-whisper" in content and "piper-tts" in content
+
+    def test_doc_voice_local_existe_avec_ram(self):
+        import os
+
+        root = os.path.join(os.path.dirname(__file__), "..")
+        doc = os.path.join(root, "docs", "VOICE-LOCAL.md")
+        assert os.path.exists(doc), "docs/VOICE-LOCAL.md doit documenter la voix locale"
+        with open(doc, encoding="utf-8") as f:
+            content = f.read().lower()
+        assert "ram" in content
+        assert "faster-whisper" in content and "piper" in content

--- a/uv.lock
+++ b/uv.lock
@@ -109,6 +109,34 @@ wheels = [
 ]
 
 [[package]]
+name = "av"
+version = "17.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/e3/477fa20578c284abeda08d91b63ee9abaebc93445d8feeb989d3d444bae1/av-17.1.0.tar.gz", hash = "sha256:7f1e71ff621b66253333926f948e00faae11d855b2442133c65128bca64cdeb3", size = 4288546, upload-time = "2026-06-07T05:52:55.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/87/8036b5c781bc3639ea04ef42d4e26da253bd4bd4311d8705b6a1c8824047/av-17.1.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ad7b4aa011093324b7118245f50ac6db244cfe9900d4072508a5245a2b0d3f41", size = 22460847, upload-time = "2026-06-07T05:52:04.261Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/af/dfdf6fc7b17814b50d0aa9e7a7e37b87be91be3890f44b0d525433cd1fd1/av-17.1.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:43ebbe977f19a7f2d2bd1a4e119675a0b15e05852cf7309846b6ab922ba7ffe9", size = 18159115, upload-time = "2026-06-07T05:52:06.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/13/64f6c466471cea225b8b2f4cdc51a571f8a286984b55a08d169b932fda5d/av-17.1.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6a20658ec7d96a70e14b1196eff00b7cdd8831ac3b99868e16b8ba8b24090847", size = 33224427, upload-time = "2026-06-07T05:52:09.165Z" },
+    { url = "https://files.pythonhosted.org/packages/77/43/96b35170bf2e64e00a41748c6400ff73232dc0fc62ded283679fb07c7fe0/av-17.1.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f9a65d1f48b818323fb411e80358f89d77dec340b01d27c6b2dfbb9cbf4b779f", size = 35370183, upload-time = "2026-06-07T05:52:11.959Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b3/8e8b4b6498731bfbd88e8399a756543f8088f1bd33d08eab678b5aebe728/av-17.1.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:58f7593726437cda5bd19793027e027768450b5c4a594777bf487798a33db702", size = 24459265, upload-time = "2026-06-07T05:52:14.66Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ac/ceb84b7553db21f1143d817245c560d9267168e1e58b1a8eeae2b62c4d04/av-17.1.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:bbab058bd965309f39962e53caac8126987c68c0be094fc4f9427e5615b0218f", size = 34283709, upload-time = "2026-06-07T05:52:17.389Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f9/4115fd84148c9a1cf365096694be6ac882fd3cd3cdb7a2f35e71fecf1631/av-17.1.0-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:9514cfda85180554c430695282faf4be3ffdf95775d8519733821244eecb58e0", size = 25397573, upload-time = "2026-06-07T05:52:20.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ac/92e52d5ed0e0b84d9d93e52b4338c2713d8a44082b8696e6516fdae7c4e4/av-17.1.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e1c90f85cd7431ede95b11e8e711571a896ebea433f298849c2c0f1594c8d86e", size = 36451495, upload-time = "2026-06-07T05:52:22.581Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f2/53a7cd34adb6a971d7e6d99663e74db286966c9db8afdca17472fdf0f98e/av-17.1.0-cp311-abi3-win_amd64.whl", hash = "sha256:5df5c1172ef1cf65a1529d612f7da7798ce2cf82c1ff7212466b538a6cc7214c", size = 28036393, upload-time = "2026-06-07T05:52:25.657Z" },
+    { url = "https://files.pythonhosted.org/packages/66/47/cd9ae0edf2206351c1251bb94b5ec58728e42c5f6ee16c03c412f3a1bb3e/av-17.1.0-cp311-abi3-win_arm64.whl", hash = "sha256:ee98534242a74da847af78624779ac5a3177dc7c69f956a4da9e6f0fdb37d7f6", size = 21174601, upload-time = "2026-06-07T05:52:28.077Z" },
+    { url = "https://files.pythonhosted.org/packages/36/90/b5668cddb3c401fcf22553bc495d5b0c6d8a01d118624b26f0db1d0b8653/av-17.1.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:5327807c1219293803ef0c5d1578ff3ae1cf638c09e5998962026e1a554ec240", size = 22699499, upload-time = "2026-06-07T05:52:30.335Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/7e/7be6bfddb823d045ff9fd5d4deb922ee3847605e162c3882e6c45b4c35ff/av-17.1.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:6c9b71fe5c0c5a8d303b1588d4d8ce9397d6b023f467cfef95000ba1f75507fa", size = 18366696, upload-time = "2026-06-07T05:52:32.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/391dcfa75c1ae1977efca44b753a11b929399b558826670c16a8808dd0e3/av-17.1.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:f997e3351bdf51127c07a74e21741a2996e9230cbeb2d81c14acde761b116c9c", size = 36582649, upload-time = "2026-06-07T05:52:35.218Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/32/7312854868b318b9d1b1dcbd1bddb460aaaeac7d57f816e11efec3bef5b1/av-17.1.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:efe9b1397300b67b644ad220c89df4892a76f2debe70f16bae1749fa20526e63", size = 38479390, upload-time = "2026-06-07T05:52:37.968Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/af47f59b4458e81ca7d89f477698dbfb3d5a0cd8ae6c1e4441d01074af8a/av-17.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:fa64e1f1500d01c4a98e7a41dc1a9a35fb4dfe71f5de0389264ec1192200c76a", size = 27127432, upload-time = "2026-06-07T05:52:40.371Z" },
+    { url = "https://files.pythonhosted.org/packages/88/85/c2e6861baf0f8c7d21c4ce811d4d424fedac915e3910d3570ce4377717dc/av-17.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ffbd78d73d2c9bf31e9a007c992faec3991428b2941a3b085b84fb82e8c32d19", size = 37406592, upload-time = "2026-06-07T05:52:43.215Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/40/3cc13125aea976101c0858af99ac47257c0654411aa199b5d8e81eea7002/av-17.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:bff8896454b38fcb785a70e5ae0485d7021cb776303a5849393128a30b8f850b", size = 28336228, upload-time = "2026-06-07T05:52:46.134Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/38/c7d9c3e746209a1a695c13e3aa7d817229e84a85d0a84271f313d1befdd3/av-17.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1284addf3c0dd939887a9722dc30df2241a97471ad52c3c507e31583ae22ff02", size = 39490680, upload-time = "2026-06-07T05:52:48.887Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/25/9d42da561b7b8f7dabdfaebba07b52977bee58c5c7e4285ac991abcfaa72/av-17.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:ec630be6321b04e317862f6082e84812bbd801e55a3c2298312e3fc8a0a4af4f", size = 28355673, upload-time = "2026-06-07T05:52:51.614Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/41/562a61d5a61fba3ffb273a115e249f1d8471b9515c59fcc38b4b9deda238/av-17.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b41647e42884bf543b8e8d0a1dabd4d1b006c99183eb1a2d7afc5b01f73eeff4", size = 21324700, upload-time = "2026-06-07T05:52:53.972Z" },
+]
+
+[[package]]
 name = "backports-tarfile"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -472,6 +500,43 @@ wheels = [
 ]
 
 [[package]]
+name = "ctranslate2"
+version = "4.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/92/ae797ea2def987a0496319c5d8988cd4aaf11a6c0c71a2fd9bbb75d13f1f/ctranslate2-4.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9f56f8de6e6e036a306d427b86d86964076b614e2358b923f93fa160139ac6f5", size = 1269068, upload-time = "2026-06-06T19:17:43.67Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/87/ed546dd5ba660c80d83a25731313956b417d35152424f92f543aec093d0e/ctranslate2-4.8.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:59c71320788b88621be143f2795048e9f510ff690c549cffc2827831f85a1a04", size = 11926418, upload-time = "2026-06-06T19:17:45.741Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ef/ab22bfafc13c5d2c5a3bbbcf89ccb140a365250df29e3226dff0cfbb6748/ctranslate2-4.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2676854f374e6720600467cbde2ea2ea844fb0b6fb3e8a79795d495a3bdc7469", size = 16705990, upload-time = "2026-06-06T19:17:48.441Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c6/29d9100520d586fc5e5142ff17b2d28e4b9beeafc196982395497700fee2/ctranslate2-4.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83336d60ae04f19a30a90405040efaea1dfa0e1d95c2fe1513e53dade4681c85", size = 39349218, upload-time = "2026-06-06T19:17:52.9Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/2b/486dc27e200f905f3acc50ed20000ee714097616f8fe66585c29c8a4b26a/ctranslate2-4.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:402472d283d844579961b8522589401bc2c50f77f1b820783b01c25060260c3c", size = 19217441, upload-time = "2026-06-06T19:17:58.36Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/f8/871b866c10d4fe4479866c4aa9c6a7ba4073dc2a657879d44411b2fb8f4c/ctranslate2-4.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:94ec37527dd815531209694854dd5177e763ed51d35b4b2c34da3c3ad2c9b9fd", size = 1269020, upload-time = "2026-06-06T19:18:00.599Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ea/316e3df68e21f79e20c277bf5c65d9825a42484ed7e3df2e6e325275ea5f/ctranslate2-4.8.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:f0b93d127a4efb6481e3d0da4c3a6ac9889a8e9d8b50f9930bc5b2401fe5e598", size = 11928718, upload-time = "2026-06-06T19:18:02.767Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d1/c4234eea5fe84733c0faed486881c7b3ebf9bc1351cb96cde7b0ecc78198/ctranslate2-4.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:edfa0c1b348525d6c2713a53c90c0c50ae7a7bb2e4d59d8a59150aadba818991", size = 16880797, upload-time = "2026-06-06T19:18:05.425Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/34/a0ac6e2538b7d730e4537cd01ded7817dda9bc97f5b6161bbd52d16e70a3/ctranslate2-4.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:247efccc2da9a63e8bf22abb4e87789f44ec1454bdcb227b07860cdc826fc89a", size = 39526315, upload-time = "2026-06-06T19:18:09.344Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ed/2c3c7b110c48c36d024c5247195f2ad4fc1e34cbf482dab62ccb3898cb70/ctranslate2-4.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:06feaafe134aafa8cb2fb1fdb82e36f050bb05929dfde1a95f4fe4d7881dfc76", size = 19218985, upload-time = "2026-06-06T19:18:12.742Z" },
+    { url = "https://files.pythonhosted.org/packages/db/59/ef2b2b0c2624122a46aed4300aaa293f83fb8cbd02543eeb4fc30e9b49ce/ctranslate2-4.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:892898271f7f2c6a3651a7ea4d91f5727f97baed36171e5026456dbf0916030a", size = 1268988, upload-time = "2026-06-06T19:18:15.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/04/7295ef780fa7cb3e0835cb5b4032a5470ca484cd4c719ac01d6665169e07/ctranslate2-4.8.0-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:aa53859acd61db1e287db57be955885fd271f84348af37dabe2c3dbd0b4425e2", size = 11928594, upload-time = "2026-06-06T19:18:16.938Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f0/23e4e7d422fe1904db8389dd2a979c8e278e2a0d56064bb54e7651372b18/ctranslate2-4.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7531ed5148099792ec488f80e21f9bb551fb9fdf335c4b6c3720f11d53f2639c", size = 16881562, upload-time = "2026-06-06T19:18:21.816Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ef/282e00f63bc1ceb45d9f0e6cb11a9f63e3f8befd980e6264e7b6b81d1536/ctranslate2-4.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3427639aa036ea3d8e6864598552dc0b32c4017801925b8165638acb937b39cf", size = 39526333, upload-time = "2026-06-06T19:18:25.383Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/6b/3c7e20503d008c62fae22c1ebe7bd4ce3c50b3033e7d97ba04c8c92e6dd1/ctranslate2-4.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:f6ab3fa77a0a4259deaf7f23979c9182974d45857873211d417fdf364a55cac5", size = 19218975, upload-time = "2026-06-06T19:18:28.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4b/24bc25460cfb36ca441e4c532d8a5bc89d84921d2af9353c4aa711cff0be/ctranslate2-4.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0ccb10af5b7ef4747d5f275e11d809ebf9057c7b1e5241fdbf386b120eaf353d", size = 1269827, upload-time = "2026-06-06T19:18:31.328Z" },
+    { url = "https://files.pythonhosted.org/packages/91/29/9fb73d9a124b3d2b44f1cf28b73ddbe793adbeb5b7366b258812fce9ff33/ctranslate2-4.8.0-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:d99095855b4f7921be85e694e20cce6a834f7d4464335150186efdf6430a3b58", size = 11929083, upload-time = "2026-06-06T19:18:33.265Z" },
+    { url = "https://files.pythonhosted.org/packages/df/8a/266ef810e2567fc4aaf322277800eff2c117a85dafcb42f08b76efc69913/ctranslate2-4.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0465bb50ddf143d02d52ea818c25a49ef5c2395c3fff98f6a905e239946cd765", size = 16870501, upload-time = "2026-06-06T19:18:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d1/ae7f0f1b4e40a00546d3f42749ae1504aaf6658e262a5c6f01269c1cae2d/ctranslate2-4.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e14648a8bed404f27d2fad5c4dbcf6eae5e584cc9641400fa443382057200c8d", size = 39491984, upload-time = "2026-06-06T19:18:40.24Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/11/be1a32f2691c5508db978937f078a296d184debf5ea03c056b2f90b0f66e/ctranslate2-4.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:1a758c95aa8f9bdaec476433515a00695b453b1315a0664612fae25b75818d44", size = 19475708, upload-time = "2026-06-06T19:18:43.782Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/68/4d10a76d9920d72ae2bba6e1601cf1ceecc06b26ad038e484ca373f0d949/ctranslate2-4.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:68405a3f88b6ec89c9768c59fded6d212b335d39c67cf0ccf058a906188a282c", size = 1292444, upload-time = "2026-06-06T19:18:46.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a5/aebac79c12c0bc3f0f55b11e56e7d7e8060f84bc69239f8a4b2a46ca9630/ctranslate2-4.8.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:39d36c67554afbed8f8cd8c03bcfb3d3453f02e96b2b6d5a0e7391daec81358d", size = 11950137, upload-time = "2026-06-06T19:18:49.436Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/21/269e389172046db797992454f26e66d8921508b3a92d7ef2bd0184b5db51/ctranslate2-4.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4791301710d8b6e1078106d4ba34e3a176f4be19f7047de06b6935b15d422bd", size = 16858464, upload-time = "2026-06-06T19:18:52.239Z" },
+    { url = "https://files.pythonhosted.org/packages/df/da/f8c28d26c9dae58042b547719295f1afc544ad31829f0d5e7fe111937d12/ctranslate2-4.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e742074822e5b27fa5b991b5ab785e6a8ae5909996023e798448fa7df478dea0", size = 39462450, upload-time = "2026-06-06T19:18:56.794Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/cd/64af7f2416be21cf8fd8ea3dbdb8e757f3b4f81b629ad43613729c5e0bd9/ctranslate2-4.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:ddc359f9b886e0f92bd3061038711285e0003dd69e7f8184cbcd29322a832458", size = 19498147, upload-time = "2026-06-06T19:19:00.4Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -545,12 +610,36 @@ wheels = [
 ]
 
 [[package]]
+name = "faster-whisper"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "av" },
+    { name = "ctranslate2" },
+    { name = "huggingface-hub" },
+    { name = "onnxruntime" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/99/49ee85903dee060d9f08297b4a342e5e0bcfca2f027a07b4ee0a38ab13f9/faster_whisper-1.2.1-py3-none-any.whl", hash = "sha256:79a66ad50688c0b794dd501dc340a736992a6342f7f95e5811be60b5224a26a7", size = 1118909, upload-time = "2025-10-31T11:35:47.794Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.20.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -1862,6 +1951,43 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/e4/5353d7e09ced4a8f473f843223fc75d726b2b5519dcefc12f22a6c92852d/onnxruntime-1.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8ba14a38c570087f3cdb8cfba33f7a38a1e826c1e5b29e17c28ceda0cc910016", size = 18416484, upload-time = "2026-06-15T22:43:43.894Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1f/a2117aa3f144fce88774efa37440d0ca72d0c9144854dfc0961f2b04c6fc/onnxruntime-1.27.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2eb083321af8a236a84c7c140a7f4cecbfa2a987a18c07c78db471c20cd390ef", size = 16419330, upload-time = "2026-06-15T22:42:37.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/cd/74bb804170ceb622fda9111df31a07b3024f7491472256d3a90b5391a4d2/onnxruntime-1.27.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4f7b0e90d2d212e2c2deaa6c8291616183ab815d3ec558ea12d3ac8b26d36f4", size = 18636930, upload-time = "2026-06-15T22:43:01.584Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8f/5b8e2b85e81735696887175dbaf6409f215683f5ca9d4928fbb038211d32/onnxruntime-1.27.0-cp311-cp311-win_amd64.whl", hash = "sha256:ff050e4f6bf7f12918fa14dcb047c0b02e295f35e86d42532552be4b3d54e977", size = 13356110, upload-time = "2026-06-15T22:43:32.172Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3a/4f568de678126b6a371a93862f015a82138359decd97fcac61fc84b5b774/onnxruntime-1.27.0-cp311-cp311-win_arm64.whl", hash = "sha256:75fbc1e1fb43a39a856c8209c544cca7817b5de7ac16b15b1bdf55d1cc67b9df", size = 13098635, upload-time = "2026-06-15T22:43:19.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/dd3a524ed93a820dff1af902d0412957ab12499953333e9daa01af5bc480/onnxruntime-1.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a14c2ce45312def86b77aea651f46565e45960cf5f0721bfdff449165086ab76", size = 18433506, upload-time = "2026-06-15T22:43:47.026Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/c3b6b17745a1997d784dadc9bd88d713d2e6721139a5a0e885b28cfb79b1/onnxruntime-1.27.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6fddce0539a4898c7bef35b052ffd37935b2190e35488eab99ce91887743ea1", size = 16438140, upload-time = "2026-06-15T22:42:40.666Z" },
+    { url = "https://files.pythonhosted.org/packages/26/81/24dd9b31b0fb912ee19ca53ac1c9764bfd79d58a2ccef564eb693be831a5/onnxruntime-1.27.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c65a7438632d55dfbc8a02ee60bd6cf7dd9d1ba05a43d4b851452f32338e194", size = 18658316, upload-time = "2026-06-15T22:43:04.012Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/88/8ec9db1a4d126bb8b758992beb40d1249df171917d75f44a327eb5f20dda/onnxruntime-1.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:20c321cf187ba496e648acf6b4cf90b4d398b0d17c2a77fdaeba365b908cc1c1", size = 13358769, upload-time = "2026-06-15T22:43:34.581Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/9f/fdad359dfcba7e7cd8815569b304a596531d4efa77a75d77f8b4981891a2/onnxruntime-1.27.0-cp312-cp312-win_arm64.whl", hash = "sha256:d0d1f68868e2ef30ef70998ba9bbbc5c305e9b17041e3936751c1b8aa6aade06", size = 13104440, upload-time = "2026-06-15T22:43:22.893Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/2b/54208fd03ad410480bc17edf4869376362da8bbf46fe186ddf4cb5cc20fe/onnxruntime-1.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:b3e5b58b8c89c2b20e086e890aa9527377e5c240dc3ecc1640d18e07705eeb1c", size = 18432958, upload-time = "2026-06-15T22:42:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/24fc51fcbb126da6d032372314e47b55c3faad58f2aa78c0e199ccd20b9c/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48b3d87eb560ff6a772240506f3c78d6d27c63cafedd5c775672e1194f968cfd", size = 16438180, upload-time = "2026-06-15T22:42:43.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/19/14929c3c2fe0b79b41cce24463062bf3afa4cdd3c19dccf00319caa92bff/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6872443f236a554921cda6f318c900e2d0c226792cf3534d00e5057c6926e5d2", size = 18658445, upload-time = "2026-06-15T22:43:08.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/76/59ed932b0244acd7bbbd6449480053a6d958ea66357f022f932872e19287/onnxruntime-1.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:760021bca514d64a811837820d351a08a41741f16f8b4c26450da708fecf14e6", size = 13357856, upload-time = "2026-06-15T22:43:37.315Z" },
+    { url = "https://files.pythonhosted.org/packages/79/51/d1ec60ec7b1e2ae2d7340ba52b8a13529140039cd4407ba8dddbbc046582/onnxruntime-1.27.0-cp313-cp313-win_arm64.whl", hash = "sha256:2fdfa9df40a0ded0028ce6f9cd863264237f3970559dea2b81456e9ac4622b94", size = 13104412, upload-time = "2026-06-15T22:43:27.457Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/e6bb1c6445c94f708c38cd8fbb7bf0264108c33498b9445c93e60fe6d329/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54c0c4e9202c36c4ecdb1f3443f5dfbfd5ee3b54d1362c4b4c6134110e74fb32", size = 16443331, upload-time = "2026-06-15T22:42:45.649Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/b18b31e806eabc41077810199fbbb36fbc2d5f19912416e5ccfbf73053d1/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b215aa662c8f983f7d6dedafe65a9be72c26e5338e0fe98b3e0422c32c85428", size = 18670967, upload-time = "2026-06-15T22:43:10.621Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/37/48ab79c39b58a7c9f6f5aac1fa0ff2b993eb2643393d6ed9e839ddb6f347/onnxruntime-1.27.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:0874edc171f470fc4dd2bbb60bc0989612ed1a8b89b365cda016630a93227f13", size = 18433941, upload-time = "2026-06-15T22:42:58.867Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/24/d535ca8a09dbf697f853377c8dc0820dbcaae5f334316b400b953afbcba8/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b51c014cf1a4fcd93c29a97eac8071fa27710dae05a4d0380bb60a66d60a62c", size = 16439970, upload-time = "2026-06-15T22:42:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b1/ea9ee80c0bdaa4efb13f29f8c236f3740f6655e8c092a2d119515a5a652c/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:445fb702ea5241ba813a3ce2febe2e9408a64f6ad2eb610924322c536165f7cd", size = 18659240, upload-time = "2026-06-15T22:43:13.165Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f2/1404507d76a21940e8bf46f414e3d1abd94dc888cb89a30f4a540275846f/onnxruntime-1.27.0-cp314-cp314-win_amd64.whl", hash = "sha256:49e416be0d717338b6d041b99911b716d70c397d277056450724f93bdded3fc2", size = 13685306, upload-time = "2026-06-15T22:43:40.416Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e5/ca5cf012ccccb806c70e94aadfebca5606acc62b33eb88cec13352d0778f/onnxruntime-1.27.0-cp314-cp314-win_arm64.whl", hash = "sha256:856032937dd3bc7a7c141909c8d7ae4fde3e3f59bddf061ae627b9a051bda95c", size = 13456280, upload-time = "2026-06-15T22:43:29.693Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7b/dca330a8397e9d816c976d7aed4e24a4a2d279bb1e551e3d0221d1389b1d/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6197a02e3f620c4dc13cff51b80672409fc1ffab3aa2593911b19fd322ff48b", size = 16443274, upload-time = "2026-06-15T22:42:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f6/2bac21f722aa45d876d4a51f26bd0ef30e704068a3cd5021a5a7cd784271/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:370d211e1ceeac4cd5f45301655463ac59e27cdc74d9f7aeb2d19ff4b7a76715", size = 18670781, upload-time = "2026-06-15T22:43:17.151Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1908,6 +2034,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/b2/bb8e495d5262bfec41ab5cb18f522f1012933347fb5d9e62452d446baca2/pathspec-1.0.3.tar.gz", hash = "sha256:bac5cf97ae2c2876e2d25ebb15078eb04d76e4b98921ee31c6f85ade8b59444d", size = 130841, upload-time = "2026-01-09T15:46:46.009Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/2b/121e912bd60eebd623f873fd090de0e84f322972ab25a7f9044c056804ed/pathspec-1.0.3-py3-none-any.whl", hash = "sha256:e80767021c1cc524aa3fb14bedda9c34406591343cc42797b386ce7b9354fb6c", size = 55021, upload-time = "2026-01-09T15:46:44.652Z" },
+]
+
+[[package]]
+name = "pathvalidate"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
 ]
 
 [[package]]
@@ -2004,6 +2139,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
     { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
     { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+]
+
+[[package]]
+name = "piper-tts"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "onnxruntime" },
+    { name = "pathvalidate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/53/3c636c4250e8cb489c50c6dda9d64400518e8c6600576850104b3232b562/piper_tts-1.4.2.tar.gz", hash = "sha256:dbe7e5391d7657f8a5f2b7ce7cdbafc5bbc559de2af15e5299ce298323eade51", size = 4364835, upload-time = "2026-04-02T21:17:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/27/5e309f1218296118e8e9ac22eeeddb0bb9a17095bd9eedcd26603eea7bf5/piper_tts-1.4.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d996f9139c44a0bedb6a9ed45805c429a827c56ef9213933859349801fa7f4e1", size = 13822408, upload-time = "2026-04-02T21:16:57.92Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e1/84fcb36c7ac413bb22eb3bdda5f21861f02d0f436df0a9090949c9fec032/piper_tts-1.4.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:138e6adf26a8e796f53866770ea30b666b65432a5e94857c2d9a8c473a8a1f90", size = 13830417, upload-time = "2026-04-02T21:17:00.665Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1c/260c65320df47fee582d78ad52d49d4195c5439a77b62e73306c2de835ea/piper_tts-1.4.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6736329f1ef58c39272215849dffdacae601201480b08a0c892938fa4d7c8c67", size = 13841991, upload-time = "2026-04-02T21:17:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/58/7b7cbd7e570ac6eb8dbfc22de94d1457863b97876c1cb6a926e959423fb2/piper_tts-1.4.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b17184a664bd9431ce95c138f4bfb3025e1280cf26075a703dbfdcab989b8ee3", size = 13841872, upload-time = "2026-04-02T21:17:06.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5a/fda959ca07554a8ec3e380b168e79fff16f3020f4956c356a613616c1994/piper_tts-1.4.2-cp39-abi3-win_amd64.whl", hash = "sha256:9c4a3a11f5889ea9d0df4414dce2bd9bee5ce7d9cf604c8fd5e307441d4c031f", size = 13831944, upload-time = "2026-04-02T21:17:08.755Z" },
 ]
 
 [[package]]
@@ -3282,6 +3434,10 @@ e2e = [
     { name = "playwright" },
     { name = "pytest-playwright" },
 ]
+voice-local = [
+    { name = "faster-whisper" },
+    { name = "piper-tts" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -3306,6 +3462,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.3" },
     { name = "einops", specifier = ">=0.8.1" },
     { name = "fastapi", specifier = ">=0.109.0" },
+    { name = "faster-whisper", marker = "extra == 'voice-local'", specifier = ">=1.0" },
     { name = "google-api-python-client", specifier = ">=2.142.0" },
     { name = "google-auth", specifier = ">=2.32.0" },
     { name = "google-auth-httplib2", specifier = ">=0.2.0" },
@@ -3320,6 +3477,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.12.0" },
     { name = "openpyxl", specifier = ">=3.1.2" },
     { name = "pillow", specifier = ">=10.0.0" },
+    { name = "piper-tts", marker = "extra == 'voice-local'", specifier = ">=1.2" },
     { name = "playwright", marker = "extra == 'e2e'", specifier = ">=1.40.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
@@ -3340,7 +3498,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
     { name = "vobject", specifier = ">=0.9.9" },
 ]
-provides-extras = ["e2e"]
+provides-extras = ["e2e", "voice-local"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Ajoute une **voix 100% locale et souveraine** (STT + TTS), **en option** (groupe pip `voice-local`, non inclus dans le build par défaut → paquet reste léger, build inchangé).

- **STT** : faster-whisper (tiny/base/small, CPU int8). **TTS** : Piper (ONNX).
- Modèles **téléchargés à la demande** (pas dans le paquet).
- Service `voice_local` (lazy) + endpoints `/api/voice/local/status`, `/api/voice/local/transcribe`, `/api/voice/tts` (renvoient 503 + indication si non installé, jamais de plantage).
- Réglages `voice_local_enabled` + `voice_local_whisper_model`.
- **Prérequis RAM documentés** : tableau dans `docs/VOICE-LOCAL.md` + exposés par `/local/status` (tiny ~1 Go, base ~1 Go, small ~2 Go ; Piper ~0,5 Go).
- 5 tests de régression.

Répond au retour testeur (Dr_logic-3D) : Groq Whisper actuel n'est ni gratuit ni souverain. Suivi : brancher l'UI (toggle réglages + bouton micro/lecture) sur ces endpoints.