### PR TITLE
fix: BUG-112 config email manuelle + BUG-114 chevauchement calendrier (nuit Zézette)

### DIFF
--- a/src/frontend/src/components/calendar/CalendarView.tsx
+++ b/src/frontend/src/components/calendar/CalendarView.tsx
@@ -10,6 +10,7 @@ import { motion } from 'framer-motion';
 import { useCalendarStore } from '../../stores/calendarStore';
 import type { CalendarEvent } from '../../services/api';
 import { getVisibleHourRange } from './calendarHours';
+import { getTimedEventLayout } from './calendarEventLayout';
 
 export function CalendarView() {
   const { events, viewMode, selectedDate, showCancelled, searchQuery, setCurrentEvent } =
@@ -322,6 +323,15 @@ function WeekView({
     () => Array.from({ length: weekEndHour - weekStartHour }, (_, i) => weekStartHour + i),
     [weekStartHour, weekEndHour]
   );
+  const layoutByEventId = useMemo(() => {
+    const layoutMap: Record<string, ReturnType<typeof getTimedEventLayout>> = {};
+
+    Object.entries(timedByDate).forEach(([dateKey, dayEvents]) => {
+      layoutMap[dateKey] = getTimedEventLayout(dayEvents, weekStartHour, weekEndHour, HOUR_HEIGHT_PX);
+    });
+
+    return layoutMap;
+  }, [timedByDate, weekStartHour, weekEndHour]);
 
   // Scroll vers l'heure courante au montage (utilise la plage dynamique :
   // se réajuste si la grille s'élargit pour un événement tôt/tard).
@@ -465,6 +475,7 @@ function WeekView({
               const dateStr = date.toISOString().split('T')[0];
               const isToday = dateStr === todayStr;
               const dayEvents = timedByDate[dateStr] || [];
+              const dayLayoutByEventId = layoutByEventId[dateStr] || {};
 
               return (
                 <div
@@ -474,8 +485,8 @@ function WeekView({
                   }`}
                 >
                   {dayEvents.map((event) => {
-                    const pos = getEventPosition(event, weekStartHour, weekEndHour, HOUR_HEIGHT_PX);
-                    if (!pos) return null;
+                    const layout = dayLayoutByEventId[event.id];
+                    if (!layout) return null;
 
                     return (
                       <motion.button
@@ -483,8 +494,13 @@ function WeekView({
                         initial={{ opacity: 0, scale: 0.95 }}
                         animate={{ opacity: 1, scale: 1 }}
                         onClick={() => onEventClick(event.id)}
-                        className="absolute left-0.5 right-0.5 bg-accent-cyan/20 hover:bg-accent-cyan/30 border-l-2 border-accent-cyan rounded-r px-2 py-1 text-left overflow-hidden transition-colors z-10"
-                        style={{ top: pos.top, height: Math.max(pos.height, 20) }}
+                        className="absolute bg-accent-cyan/20 hover:bg-accent-cyan/30 border-l-2 border-accent-cyan rounded-r px-2 py-1 text-left overflow-hidden transition-colors z-10"
+                        style={{
+                          top: layout.top,
+                          height: Math.max(layout.height, 20),
+                          left: `${layout.leftPercent}%`,
+                          width: `${layout.widthPercent}%`,
+                        }}
                       >
                         <div className="text-xs font-medium text-text truncate">
                           {event.summary}
@@ -557,6 +573,10 @@ function DayView({
   const dayHours = useMemo(
     () => Array.from({ length: dayEndHour - dayStartHour }, (_, i) => dayStartHour + i),
     [dayStartHour, dayEndHour]
+  );
+  const layoutByEventId = useMemo(
+    () => getTimedEventLayout(timedEvents, dayStartHour, dayEndHour, DAY_SLOT_HEIGHT_PX),
+    [timedEvents, dayStartHour, dayEndHour]
   );
 
   // Scroll vers l'heure courante au montage (plage dynamique : se réajuste
@@ -690,8 +710,8 @@ function DayView({
 
             {/* Événements */}
             {timedEvents.map((event) => {
-              const pos = getEventPosition(event, dayStartHour, dayEndHour, DAY_SLOT_HEIGHT_PX);
-              if (!pos) return null;
+              const layout = layoutByEventId[event.id];
+              if (!layout) return null;
 
               return (
                 <motion.button
@@ -699,8 +719,13 @@ function DayView({
                   initial={{ opacity: 0, x: -10 }}
                   animate={{ opacity: 1, x: 0 }}
                   onClick={() => onEventClick(event.id)}
-                  className="absolute left-1 right-4 bg-accent-cyan/20 hover:bg-accent-cyan/30 border-l-2 border-accent-cyan rounded-r px-3 py-2 text-left overflow-hidden transition-colors z-10"
-                  style={{ top: pos.top, height: Math.max(pos.height, 24) }}
+                  className="absolute bg-accent-cyan/20 hover:bg-accent-cyan/30 border-l-2 border-accent-cyan rounded-r px-3 py-2 text-left overflow-hidden transition-colors z-10"
+                  style={{
+                    top: layout.top,
+                    height: Math.max(layout.height, 24),
+                    left: `${layout.leftPercent}%`,
+                    width: `${layout.widthPercent}%`,
+                  }}
                 >
                   <div className="text-sm font-medium text-text truncate">
                     {event.summary}
@@ -708,7 +733,7 @@ function DayView({
                   <div className="text-xs text-text-muted">
                     {formatTime(event.start_datetime!)} - {formatTime(event.end_datetime!)}
                   </div>
-                  {event.location && pos.height > 50 && (
+                  {event.location && layout.height > 50 && (
                     <div className="text-xs text-text-muted/70 mt-0.5 truncate">
                       {event.location}
                     </div>
@@ -749,34 +774,4 @@ function getWeekDates(date: Date): Date[] {
   return dates;
 }
 
-/**
- * Calcule la position top/height d'un événement horaire dans la grille.
- */
-function getEventPosition(
-  event: CalendarEvent,
-  startHour: number,
-  endHour: number,
-  hourHeightPx: number
-): { top: number; height: number } | null {
-  if (!event.start_datetime || !event.end_datetime) return null;
 
-  const start = new Date(event.start_datetime);
-  const end = new Date(event.end_datetime);
-
-  const startMinutes = start.getHours() * 60 + start.getMinutes();
-  const endMinutes = end.getHours() * 60 + end.getMinutes();
-
-  const gridStartMinutes = startHour * 60;
-  const gridEndMinutes = endHour * 60;
-
-  // Clamper dans les bornes de la grille
-  const clampedStart = Math.max(startMinutes, gridStartMinutes);
-  const clampedEnd = Math.min(endMinutes, gridEndMinutes);
-
-  if (clampedStart >= clampedEnd) return null;
-
-  const top = ((clampedStart - gridStartMinutes) / 60) * hourHeightPx;
-  const height = ((clampedEnd - clampedStart) / 60) * hourHeightPx;
-
-  return { top, height };
-}

--- a/src/frontend/src/components/calendar/calendarEventLayout.test.ts
+++ b/src/frontend/src/components/calendar/calendarEventLayout.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { getTimedEventLayout } from './calendarEventLayout';
+import type { CalendarEvent } from '../../services/api';
+
+function buildEvent(
+  id: string,
+  start: string,
+  end: string
+): CalendarEvent {
+  return {
+    id,
+    calendar_id: 'cal-1',
+    summary: id,
+    description: null,
+    location: null,
+    start_datetime: start,
+    end_datetime: end,
+    start_date: null,
+    end_date: null,
+    all_day: false,
+    attendees: null,
+    recurrence: null,
+    status: 'confirmed',
+    synced_at: '2026-07-02T00:00:00',
+  };
+}
+
+describe('getTimedEventLayout', () => {
+  it('place deux événements au même créneau côte à côte', () => {
+    const layouts = getTimedEventLayout(
+      [
+        buildEvent('evt-a', '2026-07-02T13:00:00', '2026-07-02T14:00:00'),
+        buildEvent('evt-b', '2026-07-02T13:00:00', '2026-07-02T14:00:00'),
+      ],
+      8,
+      20,
+      60
+    );
+
+    expect(layouts['evt-a'].leftPercent).toBe(0);
+    expect(layouts['evt-a'].widthPercent).toBe(50);
+    expect(layouts['evt-b'].leftPercent).toBe(50);
+    expect(layouts['evt-b'].widthPercent).toBe(50);
+  });
+
+  it('n empile pas deux événements simplement contigus', () => {
+    const layouts = getTimedEventLayout(
+      [
+        buildEvent('evt-a', '2026-07-02T13:00:00', '2026-07-02T14:00:00'),
+        buildEvent('evt-b', '2026-07-02T14:00:00', '2026-07-02T15:00:00'),
+      ],
+      8,
+      20,
+      60
+    );
+
+    expect(layouts['evt-a'].widthPercent).toBe(100);
+    expect(layouts['evt-b'].widthPercent).toBe(100);
+  });
+
+  it('laisse un événement étendre sa largeur quand la colonne voisine est libre', () => {
+    const layouts = getTimedEventLayout(
+      [
+        buildEvent('evt-a', '2026-07-02T09:00:00', '2026-07-02T12:00:00'),
+        buildEvent('evt-b', '2026-07-02T09:00:00', '2026-07-02T10:00:00'),
+        buildEvent('evt-c', '2026-07-02T10:00:00', '2026-07-02T11:00:00'),
+      ],
+      8,
+      20,
+      60
+    );
+
+    expect(layouts['evt-a'].widthPercent).toBe(50);
+    expect(layouts['evt-b'].widthPercent).toBe(50);
+    expect(layouts['evt-c'].widthPercent).toBe(50);
+  });
+});

--- a/src/frontend/src/components/calendar/calendarEventLayout.ts
+++ b/src/frontend/src/components/calendar/calendarEventLayout.ts
@@ -1,0 +1,179 @@
+import type { CalendarEvent } from '../../services/api';
+
+export interface TimedEventLayout {
+  top: number;
+  height: number;
+  leftPercent: number;
+  widthPercent: number;
+}
+
+interface TimedEventGeometry extends TimedEventLayout {
+  eventId: string;
+  startMinutes: number;
+  endMinutes: number;
+  columnIndex: number;
+  columnCount: number;
+}
+
+interface ColumnEvent {
+  startMinutes: number;
+  endMinutes: number;
+}
+
+interface EventWithPosition {
+  event: CalendarEvent;
+  top: number;
+  height: number;
+  startMinutes: number;
+  endMinutes: number;
+}
+
+export function getTimedEventLayout(
+  events: CalendarEvent[],
+  startHour: number,
+  endHour: number,
+  hourHeightPx: number
+): Record<string, TimedEventLayout> {
+  const positionedEvents = events
+    .map((event) => getPositionedEvent(event, startHour, endHour, hourHeightPx))
+    .filter((event): event is EventWithPosition => event !== null)
+    .sort((a, b) => {
+      if (a.startMinutes !== b.startMinutes) {
+        return a.startMinutes - b.startMinutes;
+      }
+      if (a.endMinutes !== b.endMinutes) {
+        return a.endMinutes - b.endMinutes;
+      }
+      return a.event.id.localeCompare(b.event.id);
+    });
+
+  const layouts: Record<string, TimedEventLayout> = {};
+  let currentGroup: EventWithPosition[] = [];
+  let currentGroupMaxEnd = -1;
+
+  for (const event of positionedEvents) {
+    if (currentGroup.length === 0 || event.startMinutes < currentGroupMaxEnd) {
+      currentGroup.push(event);
+      currentGroupMaxEnd = Math.max(currentGroupMaxEnd, event.endMinutes);
+      continue;
+    }
+
+    applyGroupLayout(currentGroup, layouts);
+    currentGroup = [event];
+    currentGroupMaxEnd = event.endMinutes;
+  }
+
+  if (currentGroup.length > 0) {
+    applyGroupLayout(currentGroup, layouts);
+  }
+
+  return layouts;
+}
+
+function getPositionedEvent(
+  event: CalendarEvent,
+  startHour: number,
+  endHour: number,
+  hourHeightPx: number
+): EventWithPosition | null {
+  if (!event.start_datetime || !event.end_datetime) {
+    return null;
+  }
+
+  const start = new Date(event.start_datetime);
+  const end = new Date(event.end_datetime);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return null;
+  }
+
+  const startMinutes = start.getHours() * 60 + start.getMinutes();
+  const endMinutes = end.getHours() * 60 + end.getMinutes();
+  const gridStartMinutes = startHour * 60;
+  const gridEndMinutes = endHour * 60;
+  const clampedStart = Math.max(startMinutes, gridStartMinutes);
+  const clampedEnd = Math.min(endMinutes, gridEndMinutes);
+
+  if (clampedStart >= clampedEnd) {
+    return null;
+  }
+
+  return {
+    event,
+    top: ((clampedStart - gridStartMinutes) / 60) * hourHeightPx,
+    height: ((clampedEnd - clampedStart) / 60) * hourHeightPx,
+    startMinutes: clampedStart,
+    endMinutes: clampedEnd,
+  };
+}
+
+function applyGroupLayout(
+  group: EventWithPosition[],
+  layouts: Record<string, TimedEventLayout>
+) {
+  const columns: ColumnEvent[][] = [];
+  const geometries: TimedEventGeometry[] = [];
+
+  for (const item of group) {
+    let columnIndex = columns.findIndex((column) =>
+      column.every((placed) => !eventsOverlap(item.startMinutes, item.endMinutes, placed.startMinutes, placed.endMinutes))
+    );
+
+    if (columnIndex === -1) {
+      columnIndex = columns.length;
+      columns.push([]);
+    }
+
+    columns[columnIndex].push({
+      startMinutes: item.startMinutes,
+      endMinutes: item.endMinutes,
+    });
+
+    geometries.push({
+      eventId: item.event.id,
+      top: item.top,
+      height: item.height,
+      startMinutes: item.startMinutes,
+      endMinutes: item.endMinutes,
+      columnIndex,
+      columnCount: 1,
+      leftPercent: 0,
+      widthPercent: 0,
+    });
+  }
+
+  const totalColumns = Math.max(columns.length, 1);
+  const columnWidth = 100 / totalColumns;
+
+  for (const geometry of geometries) {
+    let span = 1;
+    for (let nextColumn = geometry.columnIndex + 1; nextColumn < totalColumns; nextColumn += 1) {
+      const hasConflict = columns[nextColumn].some((placed) =>
+        eventsOverlap(geometry.startMinutes, geometry.endMinutes, placed.startMinutes, placed.endMinutes)
+      );
+      if (hasConflict) {
+        break;
+      }
+      span += 1;
+    }
+
+    geometry.columnCount = span;
+    geometry.leftPercent = geometry.columnIndex * columnWidth;
+    geometry.widthPercent = columnWidth * span;
+
+    layouts[geometry.eventId] = {
+      top: geometry.top,
+      height: geometry.height,
+      leftPercent: geometry.leftPercent,
+      widthPercent: geometry.widthPercent,
+    };
+  }
+}
+
+function eventsOverlap(
+  startA: number,
+  endA: number,
+  startB: number,
+  endB: number
+): boolean {
+  return startA < endB && endA > startB;
+}

--- a/src/frontend/src/components/email/wizard/SmtpConfigStep.test.tsx
+++ b/src/frontend/src/components/email/wizard/SmtpConfigStep.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SmtpConfigStep } from './SmtpConfigStep';
+
+const mockGetEmailProviders = vi.fn();
+const mockSetupSmtpAccount = vi.fn();
+const mockTestSmtpConnection = vi.fn();
+
+vi.mock('../../../services/api', () => ({
+  getEmailProviders: (...args: unknown[]) => mockGetEmailProviders(...args),
+  setupSmtpAccount: (...args: unknown[]) => mockSetupSmtpAccount(...args),
+  testSmtpConnection: (...args: unknown[]) => mockTestSmtpConnection(...args),
+}));
+
+describe('SmtpConfigStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetEmailProviders.mockResolvedValue([
+      {
+        name: 'Gmail',
+        imap_host: 'imap.gmail.com',
+        imap_port: 993,
+        smtp_host: 'smtp.gmail.com',
+        smtp_port: 587,
+        smtp_use_tls: true,
+      },
+    ]);
+  });
+
+  it('BUG-112 : le mode manuel garde un bouton pour afficher et masquer le mot de passe', async () => {
+    render(<SmtpConfigStep onBack={vi.fn()} onSuccess={vi.fn()} />);
+
+    const toggle = await screen.findByRole('button', { name: 'Afficher le mot de passe' });
+    const passwordInput = screen.getByLabelText('Mot de passe / App password *');
+
+    expect(passwordInput).toHaveAttribute('type', 'password');
+    fireEvent.click(toggle);
+    expect(passwordInput).toHaveAttribute('type', 'text');
+    expect(screen.getByRole('button', { name: 'Masquer le mot de passe' })).toBeInTheDocument();
+  });
+
+  it('BUG-112 : Enregistrer devient cliquable en fournisseur personnalisé quand tous les champs sont remplis', async () => {
+    render(<SmtpConfigStep onBack={vi.fn()} onSuccess={vi.fn()} />);
+
+    fireEvent.change(await screen.findByLabelText('Fournisseur email'), {
+      target: { value: 'custom' },
+    });
+    fireEvent.change(screen.getByLabelText('Adresse email *'), {
+      target: { value: 'test@synoptia.fr' },
+    });
+    fireEvent.change(screen.getByLabelText('Mot de passe / App password *'), {
+      target: { value: 'motdepasse' },
+    });
+    fireEvent.change(screen.getByLabelText('Serveur IMAP *'), {
+      target: { value: 'imap.exemple.fr' },
+    });
+    fireEvent.change(screen.getByLabelText('Serveur SMTP *'), {
+      target: { value: 'smtp.exemple.fr' },
+    });
+
+    expect(screen.getByRole('button', { name: 'Enregistrer' })).toBeEnabled();
+  });
+
+  it('BUG-112 : un fournisseur prérempli ne peut pas être enregistré si un hôte est vidé', async () => {
+    render(<SmtpConfigStep onBack={vi.fn()} onSuccess={vi.fn()} />);
+
+    fireEvent.change(await screen.findByLabelText('Fournisseur email'), {
+      target: { value: 'Gmail' },
+    });
+    fireEvent.change(screen.getByLabelText('Adresse email *'), {
+      target: { value: 'test@synoptia.fr' },
+    });
+    fireEvent.change(screen.getByLabelText('Mot de passe / App password *'), {
+      target: { value: 'motdepasse' },
+    });
+    fireEvent.change(screen.getByLabelText('Serveur IMAP *'), {
+      target: { value: '' },
+    });
+
+    expect(screen.getByRole('button', { name: 'Enregistrer' })).toBeDisabled();
+  });
+});

--- a/src/frontend/src/components/email/wizard/SmtpConfigStep.tsx
+++ b/src/frontend/src/components/email/wizard/SmtpConfigStep.tsx
@@ -14,6 +14,8 @@ import {
   Loader2,
   Server,
   Plug,
+  Eye,
+  EyeOff,
 } from 'lucide-react';
 import { Button } from '../../ui/Button';
 import * as api from '../../../services/api';
@@ -47,6 +49,7 @@ export function SmtpConfigStep({ onBack, onSuccess }: SmtpConfigStepProps) {
   const [form, setForm] = useState<SmtpFormState>(DEFAULT_FORM);
   const [providers, setProviders] = useState<api.EmailProviderConfig[]>([]);
   const [selectedProvider, setSelectedProvider] = useState<string>('');
+  const [showPassword, setShowPassword] = useState(false);
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
@@ -101,8 +104,19 @@ export function SmtpConfigStep({ onBack, onSuccess }: SmtpConfigStepProps) {
     setError(null);
   }
 
+  const trimmedEmail = form.email.trim();
+  const trimmedPassword = form.password.trim();
+  const trimmedImapHost = form.imap_host.trim();
+  const trimmedSmtpHost = form.smtp_host.trim();
+  const hasCredentials = trimmedEmail.length > 0 && trimmedPassword.length > 0;
+  const hasServerConfig = trimmedImapHost.length > 0 && trimmedSmtpHost.length > 0;
+  const hasValidPorts = form.imap_port > 0 && form.smtp_port > 0;
+  const hasCompleteConfiguration = hasCredentials && hasServerConfig && hasValidPorts;
+  const canSave = hasCompleteConfiguration;
+  const canTest = hasCompleteConfiguration;
+
   async function handleTest() {
-    if (!form.email || !form.password || !form.imap_host || !form.smtp_host) {
+    if (!hasCompleteConfiguration) {
       setError('Remplis tous les champs obligatoires');
       return;
     }
@@ -130,6 +144,11 @@ export function SmtpConfigStep({ onBack, onSuccess }: SmtpConfigStepProps) {
   }
 
   async function handleSave() {
+    if (!hasCompleteConfiguration) {
+      setError('Remplis tous les champs obligatoires');
+      return;
+    }
+
     try {
       setSaving(true);
       setError(null);
@@ -144,8 +163,6 @@ export function SmtpConfigStep({ onBack, onSuccess }: SmtpConfigStepProps) {
       setSaving(false);
     }
   }
-
-  const isFormValid = form.email && form.password && form.imap_host && form.smtp_host;
 
   return (
     <motion.div
@@ -167,8 +184,9 @@ export function SmtpConfigStep({ onBack, onSuccess }: SmtpConfigStepProps) {
       {/* Provider selector */}
       {providers.length > 0 && (
         <div className="space-y-1.5">
-          <label className="text-sm text-text-muted">Fournisseur email</label>
+          <label htmlFor="smtp-provider" className="text-sm text-text-muted">Fournisseur email</label>
           <select
+            id="smtp-provider"
             value={selectedProvider}
             onChange={(e) => handleProviderSelect(e.target.value)}
             className="w-full px-3 py-2 bg-background/60 border border-border/50 rounded-lg text-sm text-text focus:outline-none focus:ring-2 focus:ring-accent-cyan/50"
@@ -187,8 +205,9 @@ export function SmtpConfigStep({ onBack, onSuccess }: SmtpConfigStepProps) {
       {/* Email + Password */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div className="space-y-1.5">
-          <label className="text-sm text-text-muted">Adresse email *</label>
+          <label htmlFor="smtp-email" className="text-sm text-text-muted">Adresse email *</label>
           <input
+            id="smtp-email"
             type="email"
             value={form.email}
             onChange={(e) => updateField('email', e.target.value)}
@@ -197,22 +216,36 @@ export function SmtpConfigStep({ onBack, onSuccess }: SmtpConfigStepProps) {
           />
         </div>
         <div className="space-y-1.5">
-          <label className="text-sm text-text-muted">Mot de passe / App password *</label>
-          <input
-            type="password"
-            value={form.password}
-            onChange={(e) => updateField('password', e.target.value)}
-            placeholder="Mot de passe applicatif"
-            className="w-full px-3 py-2 bg-background/60 border border-border/50 rounded-lg text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-accent-cyan/50"
-          />
+          <label htmlFor="smtp-password" className="text-sm text-text-muted">Mot de passe / App password *</label>
+          <div className="relative">
+            <input
+              id="smtp-password"
+              type={showPassword ? 'text' : 'password'}
+              value={form.password}
+              onChange={(e) => updateField('password', e.target.value)}
+              placeholder="Mot de passe applicatif"
+              className="w-full px-3 py-2 pr-11 bg-background/60 border border-border/50 rounded-lg text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-accent-cyan/50"
+            />
+            <button
+              type="button"
+              aria-controls="smtp-password"
+              aria-label={showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+              aria-pressed={showPassword}
+              onClick={() => setShowPassword((prev) => !prev)}
+              className="absolute inset-y-0 right-0 px-3 text-text-muted transition-colors hover:text-text"
+            >
+              {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            </button>
+          </div>
         </div>
       </div>
 
       {/* IMAP Config */}
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1.5">
-          <label className="text-sm text-text-muted">Serveur IMAP *</label>
+          <label htmlFor="smtp-imap-host" className="text-sm text-text-muted">Serveur IMAP *</label>
           <input
+            id="smtp-imap-host"
             type="text"
             value={form.imap_host}
             onChange={(e) => updateField('imap_host', e.target.value)}
@@ -221,8 +254,9 @@ export function SmtpConfigStep({ onBack, onSuccess }: SmtpConfigStepProps) {
           />
         </div>
         <div className="space-y-1.5">
-          <label className="text-sm text-text-muted">Port IMAP</label>
+          <label htmlFor="smtp-imap-port" className="text-sm text-text-muted">Port IMAP</label>
           <input
+            id="smtp-imap-port"
             type="number"
             value={form.imap_port}
             onChange={(e) => updateField('imap_port', parseInt(e.target.value) || 993)}
@@ -234,8 +268,9 @@ export function SmtpConfigStep({ onBack, onSuccess }: SmtpConfigStepProps) {
       {/* SMTP Config */}
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1.5">
-          <label className="text-sm text-text-muted">Serveur SMTP *</label>
+          <label htmlFor="smtp-smtp-host" className="text-sm text-text-muted">Serveur SMTP *</label>
           <input
+            id="smtp-smtp-host"
             type="text"
             value={form.smtp_host}
             onChange={(e) => updateField('smtp_host', e.target.value)}
@@ -244,8 +279,9 @@ export function SmtpConfigStep({ onBack, onSuccess }: SmtpConfigStepProps) {
           />
         </div>
         <div className="space-y-1.5">
-          <label className="text-sm text-text-muted">Port SMTP</label>
+          <label htmlFor="smtp-smtp-port" className="text-sm text-text-muted">Port SMTP</label>
           <input
+            id="smtp-smtp-port"
             type="number"
             value={form.smtp_port}
             onChange={(e) => updateField('smtp_port', parseInt(e.target.value) || 587)}
@@ -311,7 +347,7 @@ export function SmtpConfigStep({ onBack, onSuccess }: SmtpConfigStepProps) {
             variant="secondary"
             size="sm"
             onClick={handleTest}
-            disabled={!isFormValid || testing}
+            disabled={!canTest || testing}
           >
             {testing ? (
               <Loader2 className="w-4 h-4 mr-1 animate-spin" />
@@ -325,7 +361,7 @@ export function SmtpConfigStep({ onBack, onSuccess }: SmtpConfigStepProps) {
             variant="primary"
             size="sm"
             onClick={handleSave}
-            disabled={!isFormValid || saving}
+            disabled={!canSave || saving}
           >
             {saving ? (
               <Loader2 className="w-4 h-4 mr-1 animate-spin" />

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -134,6 +134,54 @@ class TestBUG110_UpdateBloquee:
         except Exception:
             pytest.fail("Clé publique mal encodée en base64")
 
+
+class TestBUG112_EmailManuelAutreFournisseur:
+    """BUG-112 : le mode manuel doit garder le toggle mot de passe et autoriser l'enregistrement."""
+
+    SMTP_TSX = FRONTEND / "components" / "email" / "wizard" / "SmtpConfigStep.tsx"
+
+    def test_bug112_password_visibility_toggle_present(self):
+        content = self.SMTP_TSX.read_text(encoding="utf-8")
+        assert "showPassword" in content, (
+            "SmtpConfigStep doit garder un état showPassword pour le mode manuel"
+        )
+        assert "type={showPassword ? 'text' : 'password'}" in content, (
+            "Le champ mot de passe doit pouvoir alterner entre texte et password"
+        )
+
+    def test_bug112_manual_can_save_logic_present(self):
+        content = self.SMTP_TSX.read_text(encoding="utf-8")
+        assert "canSave" in content, (
+            "SmtpConfigStep doit calculer une condition de sauvegarde dédiée"
+        )
+        assert "hasCompleteConfiguration" in content, (
+            "La sauvegarde doit exiger une configuration SMTP/IMAP complète"
+        )
+
+
+class TestBUG114_CalendarOverlappingEvents:
+    """BUG-114 : les événements simultanés doivent avoir un layout dédié."""
+
+    CALENDAR_VIEW_TSX = FRONTEND / "components" / "calendar" / "CalendarView.tsx"
+
+    def test_bug114_week_view_uses_overlap_layout(self):
+        content = self.CALENDAR_VIEW_TSX.read_text(encoding="utf-8")
+        assert "getTimedEventLayout" in content, (
+            "WeekView doit calculer un layout pour les événements qui se chevauchent"
+        )
+        assert "left: `${layout.leftPercent}%`" in content, (
+            "WeekView doit positionner horizontalement les événements simultanés"
+        )
+
+    def test_bug114_day_view_uses_overlap_layout(self):
+        content = self.CALENDAR_VIEW_TSX.read_text(encoding="utf-8")
+        assert "width: `${layout.widthPercent}%`" in content, (
+            "DayView doit réduire la largeur des événements simultanés"
+        )
+        assert "layoutByEventId" in content, (
+            "Le layout chevauché doit être calculé une seule fois par vue"
+        )
+
 # ============================================================
 # BUG-002 (v0.1.2) - Port dynamique
 # Le backend ne doit PAS utiliser un port hardcodé 8000.


### PR DESCRIPTION
## Deux fixes issus du batch nocturne de Zézette (branche reprise et poussée à la main)

### BUG-112 - Email « autre fournisseur » : toggle mot de passe + Enregistrer grisé
- Toggle Eye/EyeOff permanent (le révélateur natif WebView2 disparaissait après perte de focus, cf complément Dr_logic-3D du 27/06)
- Validation unifiée `hasCompleteConfiguration` (valeurs trimées, ports > 0) pour **Tester** et **Enregistrer**, garde défensive dans `handleSave`
- Accessibilité : `label htmlFor`/`id` sur tous les champs
- Tests : `SmtpConfigStep.test.tsx` + `TestBUG112` (régression)

### BUG-114 - Calendrier : événements simultanés côte à côte
- Nouveau helper `calendarEventLayout.ts` : groupes de recouvrement, colonnes gloutonnes, expansion de largeur
- Vues semaine + jour branchées sur `leftPercent`/`widthPercent` (remplace le positionnement `left/right` fixe)
- Tests : `calendarEventLayout.test.ts` + `TestBUG114` (régression)

Signalés par Dr_logic-3D (Win10) et Capov sur Discord. Vérifs Zézette : pytest, vitest, tsc, eslint OK. Repassé pytest sur le VPS avant push : 100 % PASS.