### PR TITLE
fix(installer): BUG-113 doublon d'icônes bureau Windows (raccourci legacy THÉRÈSE.lnk)

### DIFF
--- a/src/frontend/src-tauri/installer-hooks.nsh
+++ b/src/frontend/src-tauri/installer-hooks.nsh
@@ -1,5 +1,30 @@
-; Hooks NSIS personnalises pour l'installeur Windows de THERESE (Tauri v2).
+﻿; Hooks NSIS personnalises pour l'installeur Windows de THERESE (Tauri v2).
 ;
+; ENCODAGE : ce fichier DOIT rester en UTF-8 AVEC BOM. La macro POSTINSTALL
+; contient des noms de fichiers accentues ("THÉRÈSE.lnk") ; sans BOM,
+; makensis interprete le fichier dans la codepage ANSI du systeme et les
+; litteraux accentues sont corrompus (le Delete viserait un mauvais nom).
+;
+; BUG-113 : jusqu'a la v0.1.15, productName valait "THÉRÈSE" (accentue) et
+; l'installeur creait un raccourci bureau "THÉRÈSE.lnk". Le renommage en
+; "THERESE" (v0.1.16) a laisse cet ancien .lnk orphelin : Windows est
+; insensible a la casse mais pas aux accents, donc chaque installation ou
+; mise a jour recree "THERESE.lnk" A COTE de l'ancien -> deux icones qui
+; pointent sur la meme cible. On purge donc le raccourci legacy (bureau
+; utilisateur ET bureau commun, au cas ou une vieille installation machine
+; en aurait laisse un). L'installation courante est perUser (installMode
+; par defaut de Tauri) : son raccourci frais vit dans le bureau utilisateur
+; sous le nom "THERESE.lnk" et n'est pas touche par ces suppressions.
+
+!macro NSIS_HOOK_POSTINSTALL
+  ; Purge des raccourcis bureau legacy en doublon (BUG-113).
+  Delete "$DESKTOP\THÉRÈSE.lnk"
+  SetShellVarContext all
+  Delete "$DESKTOP\THERESE.lnk"
+  Delete "$DESKTOP\THÉRÈSE.lnk"
+  SetShellVarContext current
+!macroend
+
 ; BUG-111 : a la desinstallation, quand l'utilisateur coche
 ; "Supprimer les donnees de l'application", Tauri efface bien les dossiers
 ; standards de l'app ($APPDATA / $LOCALAPPDATA\fr.synoptia.therese), MAIS pas
@@ -14,6 +39,8 @@
 ; le dossier de donnees backend.
 
 !macro NSIS_HOOK_POSTUNINSTALL
+  ; Purge aussi le raccourci legacy accentue a la desinstallation (BUG-113).
+  Delete "$DESKTOP\THÉRÈSE.lnk"
   ${If} $DeleteAppDataCheckboxState = 1
     ; Dossier de donnees backend THERESE (db, parametrages, projets, images,
     ; conversations, comptes, cle de chiffrement...).

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -7667,6 +7667,45 @@ class TestBUG111_UninstallDeleteData:
         )
 
 
+class TestBUG113_RaccourciBureauLegacyDoublon:
+    """BUG-113 : après une MAJ Windows, deux icônes bureau pointent sur la même
+    cible. Cause : jusqu'à la v0.1.15 le productName était « THÉRÈSE » (accentué),
+    le renommage en « THERESE » (v0.1.16) a laissé l'ancien .lnk orphelin que
+    chaque installation recrée à côté. Fix : hook NSIS POSTINSTALL qui purge les
+    raccourcis legacy (accentué + bureau commun).
+    """
+
+    def _hook_path(self):
+        import os
+        return os.path.join(
+            os.path.dirname(__file__), "..", "src", "frontend", "src-tauri",
+            "installer-hooks.nsh",
+        )
+
+    def test_hook_postinstall_purge_raccourci_legacy(self):
+        with open(self._hook_path(), encoding="utf-8-sig") as f:
+            content = f.read()
+        assert "NSIS_HOOK_POSTINSTALL" in content, (
+            "Le hook doit définir NSIS_HOOK_POSTINSTALL (purge raccourcis legacy)"
+        )
+        assert 'Delete "$DESKTOP\\THÉRÈSE.lnk"' in content, (
+            "Le hook doit supprimer le raccourci legacy accentué THÉRÈSE.lnk"
+        )
+        assert "SetShellVarContext all" in content and "SetShellVarContext current" in content, (
+            "Le hook doit aussi purger le bureau commun puis restaurer le contexte user"
+        )
+
+    def test_hook_fichier_utf8_avec_bom(self):
+        # makensis lit le .nsh en codepage ANSI sans BOM : les littéraux
+        # accentués seraient corrompus et le Delete viserait un mauvais nom.
+        with open(self._hook_path(), "rb") as f:
+            raw = f.read(3)
+        assert raw == b"\xef\xbb\xbf", (
+            "installer-hooks.nsh doit être encodé en UTF-8 AVEC BOM "
+            "(littéraux accentués dans les macros NSIS)"
+        )
+
+
 class TestVoiceLocalOption:
     """Voix locale souveraine STT/TTS, OPTIONNELLE (faster-whisper + Piper).
 


### PR DESCRIPTION
## Cause racine (identifiée via l'historique git)

Jusqu'à la **v0.1.15**, `productName` valait **« THÉRÈSE »** (accentué) → l'installeur créait `THÉRÈSE.lnk` sur le bureau. Le renommage en **« THERESE »** (v0.1.16, février) a laissé cet ancien `.lnk` orphelin : Windows est insensible à la casse mais **pas aux accents**, donc chaque install/MAJ recrée `THERESE.lnk` à côté → deux icônes pointant sur la même cible. Exactement le symptôme rapporté par Dr_logic-3D (testeur depuis février) après la MAJ auto 0.25 → 0.26.

## Fix

- `NSIS_HOOK_POSTINSTALL` : purge `THÉRÈSE.lnk` (bureau user + bureau commun) et `THERESE.lnk` du bureau commun (orphelin d'une éventuelle vieille install machine). L'install courante est perUser : son raccourci frais n'est pas touché.
- `NSIS_HOOK_POSTUNINSTALL` : purge aussi le legacy à la désinstallation.
- **Fichier passé en UTF-8 avec BOM** : sans BOM, makensis lit le `.nsh` en codepage ANSI et corromprait les littéraux accentués. Un test garde ce point (`test_hook_fichier_utf8_avec_bom`).

## Note

Zézette avait escaladé ce bug faute de repro Windows (`bug-queue/escalated/`). Validation réelle à faire par Dr_logic-3D à la prochaine MAJ : l'icône en double doit disparaître d'elle-même.