### PR TITLE
fix(projets): BUG-041 drag & drop entre rubriques - toute la carte est draggable

### DIFF
--- a/src/frontend/src/components/memory/ProjectsKanban.test.tsx
+++ b/src/frontend/src/components/memory/ProjectsKanban.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Tests ProjectsKanban - régression BUG-041.
+ *
+ * Le drag & drop des projets entre rubriques (statuts) était inopérant pour
+ * l'utilisateur : les listeners de useSortable n'étaient posés que sur la
+ * poignée GripVertical (16px, quasi invisible), pas sur la carte. Attraper
+ * la carte par son corps - le geste naturel - ne démarrait aucun drag.
+ * Ces tests vérifient que le drag s'active depuis le corps de la carte
+ * (pointeur et clavier) et que le clic simple continue d'ouvrir le projet.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ProjectsKanban } from './ProjectsKanban';
+import type { Project } from '../../services/api';
+
+function makeProject(overrides: Partial<Project> & Pick<Project, 'id' | 'name' | 'status'>): Project {
+  return {
+    description: null,
+    contact_id: null,
+    budget: null,
+    notes: null,
+    tags: null,
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const projects: Project[] = [
+  makeProject({ id: 'p-alpha', name: 'Projet Alpha', status: 'active' }),
+  makeProject({ id: 'p-gamma', name: 'Projet Gamma', status: 'on_hold' }),
+];
+
+function renderKanban() {
+  const onSelect = vi.fn();
+  const onDelete = vi.fn();
+  const onStatusChange = vi.fn().mockResolvedValue(undefined);
+  render(
+    <ProjectsKanban
+      projects={projects}
+      onSelect={onSelect}
+      onDelete={onDelete}
+      onStatusChange={onStatusChange}
+    />
+  );
+  return { onSelect, onDelete, onStatusChange };
+}
+
+/** Le wrapper sortable de la carte (élément portant role + tabIndex posés par useSortable). */
+function getSortableWrapper(projectName: string): HTMLElement {
+  const title = screen.getByText(projectName);
+  const wrapper = title.closest('[aria-roledescription="sortable"]');
+  if (!(wrapper instanceof HTMLElement)) {
+    throw new Error(`Wrapper sortable introuvable pour ${projectName}`);
+  }
+  return wrapper;
+}
+
+describe('ProjectsKanban drag & drop (BUG-041)', () => {
+  it('démarre un drag au pointeur depuis le corps de la carte (pas seulement la poignée)', () => {
+    renderKanban();
+
+    // Geste utilisateur : attraper la carte par son titre, puis bouger au-delà
+    // de l'activationConstraint (distance 8px).
+    const title = screen.getByText('Projet Alpha');
+    fireEvent.pointerDown(title, {
+      button: 0,
+      isPrimary: true,
+      pointerId: 1,
+      clientX: 5,
+      clientY: 5,
+    });
+    fireEvent.pointerMove(document, { pointerId: 1, clientX: 5, clientY: 40 });
+
+    // Drag actif = le DragOverlay rend une seconde carte du même projet.
+    expect(screen.getAllByText('Projet Alpha')).toHaveLength(2);
+
+    fireEvent.pointerUp(document, { pointerId: 1 });
+  });
+
+  it('démarre un drag au clavier depuis la carte focusée (Entrée)', async () => {
+    renderKanban();
+
+    const wrapper = getSortableWrapper('Projet Gamma');
+    wrapper.focus();
+    fireEvent.keyDown(wrapper, { code: 'Enter' });
+
+    expect(screen.getAllByText('Projet Gamma')).toHaveLength(2);
+
+    // Terminer proprement le drag, sinon son état pollue le test suivant.
+    // Le KeyboardSensor attache son listener keydown au document dans un
+    // setTimeout(0) : il faut laisser passer un tick avant d'annuler.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    fireEvent.keyDown(wrapper, { code: 'Escape' });
+    await waitFor(() => expect(screen.getAllByText('Projet Gamma')).toHaveLength(1));
+  });
+
+  it('un clic simple sur le titre ouvre toujours le projet (pas de drag parasite)', () => {
+    const { onSelect } = renderKanban();
+
+    fireEvent.click(screen.getByText('Projet Alpha'));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].id).toBe('p-alpha');
+  });
+});

--- a/src/frontend/src/components/memory/ProjectsKanban.tsx
+++ b/src/frontend/src/components/memory/ProjectsKanban.tsx
@@ -148,6 +148,7 @@ export function ProjectsKanban({ projects, onSelect, onDelete, onStatusChange }:
       collisionDetection={closestCorners}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
+      onDragCancel={() => setActiveProject(null)}
     >
       <div className="divide-y divide-border/30">
         {STATUS_COLUMNS.map((column) => (
@@ -168,6 +169,7 @@ export function ProjectsKanban({ projects, onSelect, onDelete, onStatusChange }:
             onSelect={() => {}}
             onDelete={() => {}}
             isOverlay
+            showDragHandle
           />
         )}
       </DragOverlay>
@@ -257,13 +259,24 @@ function SortableProjectCard({ project, onSelect, onDelete }: SortableProjectCar
     opacity: isDragging ? 0.4 : 1,
   };
 
+  // BUG-041 : les listeners couvrent toute la carte (même idiome que le
+  // PipelineView CRM), pas seulement la poignée - sinon attraper la carte
+  // par son corps ne démarre aucun drag. Les clics simples (ouvrir,
+  // supprimer) restent distingués du drag par l'activationConstraint
+  // (distance 8px) du PointerSensor.
   return (
-    <div ref={setNodeRef} style={style} {...attributes}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="cursor-grab active:cursor-grabbing"
+      {...attributes}
+      {...listeners}
+    >
       <ProjectCard
         project={project}
         onSelect={onSelect}
         onDelete={onDelete}
-        dragListeners={listeners}
+        showDragHandle
       />
     </div>
   );
@@ -278,10 +291,10 @@ interface ProjectCardProps {
   onSelect: (project: Project) => void;
   onDelete: (project: Project) => void;
   isOverlay?: boolean;
-  dragListeners?: Record<string, unknown>;
+  showDragHandle?: boolean;
 }
 
-function ProjectCard({ project, onSelect, onDelete, isOverlay, dragListeners }: ProjectCardProps) {
+function ProjectCard({ project, onSelect, onDelete, isOverlay, showDragHandle }: ProjectCardProps) {
   return (
     <motion.div
       whileHover={isOverlay ? undefined : { scale: 1.01 }}
@@ -291,13 +304,9 @@ function ProjectCard({ project, onSelect, onDelete, isOverlay, dragListeners }: 
       }`}
     >
       <div className="flex items-center gap-2">
-        {/* Drag Handle */}
-        {dragListeners && (
-          <div
-            className="cursor-grab active:cursor-grabbing text-text-muted/30 hover:text-text-muted flex-shrink-0"
-            {...dragListeners}
-            onClick={(e) => e.stopPropagation()}
-          >
+        {/* Poignée (repère visuel : toute la carte est draggable) */}
+        {showDragHandle && (
+          <div className="text-text-muted/30 group-hover:text-text-muted flex-shrink-0">
             <GripVertical className="w-4 h-4" />
           </div>
         )}


### PR DESCRIPTION
## BUG-041 - Projets : drag & drop entre rubriques inopérant

Fiche escaladée du 16/06/2026 (testeur Dr_logic-3D). Note : l'analyse de Zézette du fichier escaladé portait sur le repo Server (v0.4.7, pas de module Projets) — le module vit dans ce repo Desktop (`src/frontend/src/components/memory/ProjectsKanban.tsx`).

### Cause racine

Les `listeners` de `useSortable` n'étaient posés que sur la poignée `GripVertical` (16 px, `text-text-muted/30`, quasi invisible). Attraper la carte par son corps — le geste naturel — ne démarrait aucun drag, dans toutes les directions (le « peut-être uniquement au sein d'une même rubrique ? » de la fiche était une spéculation : sans la poignée, rien ne bougeait nulle part). La logique de drop (`handleDragEnd`, PATCH statut, `on_hold` accepté par le backend) était saine — reproduit et confirmé en conditions réelles (Playwright, sandbox `THERESE_DATA_DIR` isolée) : drag via poignée = OK, drag via corps de carte = aucun événement.

### Fix

- `listeners` sur le wrapper entier de `SortableProjectCard` — même idiome que le `PipelineView` CRM. Les clics simples (ouvrir, supprimer) restent distingués du drag par l'`activationConstraint` (distance 8 px) déjà en place.
- La poignée devient un repère visuel (`group-hover`), affichée aussi dans le `DragOverlay` (pas de saut visuel au décollage).
- `onDragCancel` ajouté : le fix rend le drag clavier atteignable (focus + Entrée, a11y) et sans ce handler, Échap laissait un overlay fantôme.

### Vérifications

- Test de régression Vitest `ProjectsKanban.test.tsx` (rouge avant fix, vert après) : drag pointeur depuis le corps de la carte, drag clavier, clic simple préservé.
- En réel (navigateur, sandbox isolée) : drag corps de carte inter-rubriques → PATCH `{"status": ...}` émis + UI à jour ; drop sur rubrique vide OK ; clic simple ouvre la modale d'édition ; aucune modale parasite post-drop.
- Suite frontend complète : 248 tests verts. ESLint : 0 erreur (26 warnings préexistants, seuil 27). `tsc --noEmit` propre.

### Hors périmètre (constaté, non traité ici)

`TaskKanban.tsx` a le même pattern poignée-seule (listeners sur le grip). Aucun bug ouvert dessus ; à harmoniser éventuellement dans un lot séparé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)