### PR TITLE
fix(chat): BUG-115 confirmation d'envoi email visible malgré le panneau guidé (nuit Zézette)

### DIFF
--- a/src/frontend/src/components/chat/ChatLayout.test.tsx
+++ b/src/frontend/src/components/chat/ChatLayout.test.tsx
@@ -1,0 +1,98 @@
+import { useEffect } from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatLayout } from './ChatLayout';
+import { useToolConfirmationStore } from '../../stores/toolConfirmationStore';
+import { useNavigationStore } from '../../stores/navigationStore';
+import { usePersonalisationStore } from '../../stores/personalisationStore';
+
+vi.mock('./ChatHeader', () => ({
+  ChatHeader: () => <div data-testid="chat-header" />,
+}));
+
+vi.mock('./MessageList', () => ({
+  MessageList: ({ onGuidedPanelChange }: { onGuidedPanelChange?: (active: boolean) => void }) => {
+    useEffect(() => {
+      onGuidedPanelChange?.(true);
+    }, [onGuidedPanelChange]);
+    return <div data-testid="message-list" />;
+  },
+}));
+
+vi.mock('./ChatInput', () => ({
+  ChatInput: () => <div data-testid="chat-input" />,
+}));
+
+vi.mock('./CommandPalette', () => ({
+  CommandPalette: () => null,
+}));
+
+vi.mock('./ConversationMemoryChip', () => ({
+  ConversationMemoryChip: () => <div data-testid="conversation-memory-chip" />,
+}));
+
+vi.mock('./ShortcutsModal', () => ({
+  ShortcutsModal: () => null,
+}));
+
+vi.mock('../sidebar/ConversationSidebar', () => ({
+  ConversationSidebar: () => null,
+}));
+
+vi.mock('../files/DropZone', () => ({
+  DropZone: () => null,
+}));
+
+vi.mock('./PanelContainer', () => ({
+  PanelContainer: () => null,
+}));
+
+vi.mock('../ui/SideToggle', () => ({
+  SideToggle: () => null,
+}));
+
+vi.mock('../ui/ConnectionStatus', () => ({
+  ConnectionStatus: () => null,
+}));
+
+vi.mock('../../hooks', () => ({
+  useKeyboardShortcuts: () => {},
+  useConversationSync: () => {},
+  useFileDrop: () => ({ isDragging: false }),
+  useOnlineStatus: () => true,
+}));
+
+vi.mock('../../services/api/commands', () => ({
+  listUserCommands: vi.fn().mockResolvedValue([]),
+}));
+
+describe('ChatLayout', () => {
+  beforeEach(() => {
+    localStorage.setItem('therese-skip-dashboard', 'true');
+    usePersonalisationStore.setState({ skipDashboard: true });
+    useNavigationStore.setState({ activeView: 'chat', history: [], initializeView: () => {} });
+    useToolConfirmationStore.setState({
+      pending: [
+        {
+          confirmation_id: 'bug114',
+          tool_name: 'send_email',
+          arguments: {
+            to: 'merci@example.fr',
+            subject: 'Merci',
+            body: 'Merci pour votre retour.',
+          },
+        },
+      ],
+    });
+  });
+
+  it('affiche la confirmation d\'envoi même si le panneau guidé est actif', async () => {
+    render(<ChatLayout />);
+    act(() => {
+      useNavigationStore.setState({ activeView: 'chat' });
+    });
+
+    expect(await screen.findByText("Confirmer l'envoi de l'email")).toBeInTheDocument();
+    expect(screen.getByText('merci@example.fr')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/chat/ChatLayout.tsx
+++ b/src/frontend/src/components/chat/ChatLayout.tsx
@@ -255,10 +255,11 @@ export function ChatLayout() {
             <div className="flex-1 overflow-hidden">
               <MessageList onPromptSelect={handleGuidedPromptSelect} onSaveAsCommand={(u, a) => ps.openSaveCommand(u, a)} onGuidedPanelChange={setGuidedPanelActive} />
             </div>
+            {/* BUG-114 : la confirmation d'envoi doit rester visible même si un
+                panneau guidé est encore ouvert, sinon l'action semble bloquée. */}
+            <ToolConfirmationCard />
             {!guidedPanelActive && (
               <>
-                {/* US-002 : actions sensibles (envoi d'email) à valider */}
-                <ToolConfirmationCard />
                 {/* L6 : pastille de glance « N contacts liés à cette conversation » */}
                 <ConversationMemoryChip />
                 <div className="border-t border-border">


### PR DESCRIPTION
## Contexte

Signalé par Dr_logic-3D (v0.26.1, Windows 10), jugé **bloquant** : après génération d'un email depuis le chat (flux guidé), aucune carte de confirmation `send_email` n'apparaît. L'utilisateur reste avec un texte généré sans action possible.

> Renuméroté **BUG-115** le 07/07 (collision : BUG-114 = chevauchement calendrier, releasé v0.26.1).

## Cause racine

`ToolConfirmationCard` était rendue à l'intérieur du bloc `!guidedPanelActive` de `ChatLayout.tsx` : la confirmation existait bien dans le store Zustand mais restait invisible tant qu'un panneau guidé était actif.

## Fix

- La carte de confirmation est sortie du bloc conditionnel (toujours rendue).
- Le champ de saisie et la pastille mémoire restent masqués pendant le panneau guidé (comportement inchangé).
- Test de régression : `ChatLayout.test.tsx`.

## Vérifications

- Tests ciblés ChatLayout + ToolConfirmationCard : 4/4 verts (relancés sur le VPS avant commit)
- Suite frontend complète (nuit Zézette) : 43 fichiers, 249 tests verts
- Revue challenger Zézette : approuvée

Fix développé par Zézette (batch nocturne du 07/07), récupéré du working tree VPS (le batch n'avait ni commité ni poussé - le script de nuit a désormais un filet git anti-perte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)